### PR TITLE
lookup no longer takes a SocketAddr

### DIFF
--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -454,10 +454,6 @@ impl<'de> Reader {
     /// let city: geoip2::City = reader.lookup(ip).unwrap();
     /// print!("{:?}", city);
     /// ```
-    ///
-    /// Note that SocketAddr requires a port, which is not needed to look up
-    /// the address in the database. This library will likely switch to IpAddr
-    /// if the feature gate for that is removed.
     pub fn lookup<T>(&self, address: IpAddr) -> Result<T, MaxMindDBError>
     where
         T: Deserialize<'de>,


### PR DESCRIPTION
neat crate! I noticed when reading through the crate docs that `lookup` had a comment that seemed like an artifact of a past implementation detail. this pull removes the comment to avoid future confusion.