### PR TITLE
Reader::open takes an AsRef<Path>

### DIFF
--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -393,10 +393,12 @@ impl<'de> Reader {
     /// ```
     /// let reader = maxminddb::Reader::open("test-data/test-data/GeoIP2-City-Test.mmdb").unwrap();
     /// ```
-    pub fn open(database: &str) -> Result<Reader, MaxMindDBError> {
-        let data_section_separator_size = 16;
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Reader, MaxMindDBError> {
+        Reader::open_(path.as_ref())
+    }
+    fn open_(path: &Path) -> Result<Reader, MaxMindDBError> {
 
-        let path = Path::new(database);
+        let data_section_separator_size = 16;
 
         let mut f = File::open(&path)?;
 

--- a/src/maxminddb/reader_test.rs
+++ b/src/maxminddb/reader_test.rs
@@ -136,7 +136,7 @@ fn test_reader() {
                 "test-data/test-data/MaxMind-DB-test-ipv{}-{}.mmdb",
                 ip_version, record_size
             );
-            let reader = Reader::open(filename.as_ref()).ok().unwrap();
+            let reader = Reader::open(filename).ok().unwrap();
 
             check_metadata(&reader, *ip_version, *record_size);
             check_ip(&reader, *ip_version);


### PR DESCRIPTION
Changes the argument signature of `Reader::open` from `&str` to `AsRef<Path>` to be more canonical.

There is breaking changes similar to this:
```
error[E0283]: type annotations required: cannot resolve `std::string::Str
ing: std::convert::AsRef<_>`
   --> src/maxminddb/reader_test.rs:139:48
    |
139 |             let reader = Reader::open(filename.as_ref()).ok().unwra
p();
    |                                                ^^^^^^

error: aborting due to previous error
```
however those breaks should be fairly simple to fix for users.