### PR TITLE
Derive serialize for GeoIP2 models

### DIFF
--- a/src/maxminddb/geoip2.rs
+++ b/src/maxminddb/geoip2.rs
@@ -1,5 +1,5 @@
 /// GeoIP2 Country record
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Country {
     pub continent: Option<model::Continent>,
     pub country: Option<model::Country>,
@@ -9,7 +9,7 @@ pub struct Country {
 }
 
 /// GeoIP2 City record
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct City {
     pub city: Option<model::City>,
     pub continent: Option<model::Continent>,
@@ -23,7 +23,7 @@ pub struct City {
 }
 
 /// GeoIP2 ISP record
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Isp {
     pub autonomous_system_number: Option<u32>,
     pub autonomous_system_organization: Option<String>,
@@ -32,13 +32,13 @@ pub struct Isp {
 }
 
 /// GeoIP2 Connection-Type record
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct ConnectionType {
     pub connection_type: Option<String>,
 }
 
 /// GeoIP2 Anonymous Ip record
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct AnonymousIp {
     pub is_anonymous: Option<bool>,
     pub is_public_proxy: Option<bool>,
@@ -47,27 +47,27 @@ pub struct AnonymousIp {
 pub mod model {
     use std::collections::BTreeMap;
 
-    #[derive(Deserialize, Clone, Debug)]
+    #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct City {
         pub geoname_id: Option<u32>,
         pub names: Option<BTreeMap<String, String>>,
     }
 
-    #[derive(Deserialize, Clone, Debug)]
+    #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct Continent {
         pub code: Option<String>,
         pub geoname_id: Option<u32>,
         pub names: Option<BTreeMap<String, String>>,
     }
 
-    #[derive(Deserialize, Clone, Debug)]
+    #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct Country {
         pub geoname_id: Option<u32>,
         pub iso_code: Option<String>,
         pub names: Option<BTreeMap<String, String>>,
     }
 
-    #[derive(Deserialize, Clone, Debug)]
+    #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct Location {
         pub latitude: Option<f64>,
         pub longitude: Option<f64>,
@@ -75,26 +75,26 @@ pub mod model {
         pub time_zone: Option<String>,
     }
 
-    #[derive(Deserialize, Clone, Debug)]
+    #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct Postal {
         pub code: Option<String>,
     }
 
-    #[derive(Deserialize, Clone, Debug)]
+    #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct RepresentedCountry {
         pub geoname_id: Option<u32>,
         pub iso_code: Option<String>,
         pub names: Option<BTreeMap<String, String>>, // pub type: Option<String>,
     }
 
-    #[derive(Deserialize, Clone, Debug)]
+    #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct Subdivision {
         pub geoname_id: Option<u32>,
         pub iso_code: Option<String>,
         pub names: Option<BTreeMap<String, String>>,
     }
 
-    #[derive(Deserialize, Clone, Debug)]
+    #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct Traits {
         pub is_anonymous_proxy: Option<bool>,
         pub is_satellite_provider: Option<bool>,


### PR DESCRIPTION
This pull request derives the `Serialize` trait from Serde for all of the geoip2 models. I know it's not required by this library, however without this addition, attempting to serialize these structs into something like json is pretty painful.

Thanks for the consideration!