### PR TITLE
Add performance benchmarks using Criterion.rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Cargo.lock
 GeoLite2-City.mmdb
 target
+GeoIP2-City.mmdb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,14 @@ memmap = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.5"
+criterion = "0.3"
+fake = "2.2.0"
+rayon = "1.2.0"
+
 
 [badges]
 travis-ci = { repository = "oschwald/maxminddb-rust" }
 
+[[bench]]
+name = "lookup"
+harness = false

--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ The API docs are on [GitHub Pages](http://oschwald.github.io/maxminddb-rust/maxm
 
 See [`examples/lookup.rs`](https://github.com/oschwald/maxminddb-rust/blob/master/examples/lookup.rs) for a basic example.
 
+## Benchmarks ##
+
+The projects include benchmarks using [Criterion.rs](https://github.com/bheisler/criterion.rs).
+
+First you need to have a working copy of the GeoIP City database.
+You can fetch it from [here](https://dev.maxmind.com/geoip/geoip2/geolite2/).
+
+Place it in the root folder as `GeoIP2-City.mmdb`.
+
+Once this is done, run
+
+```
+cargo bench
+```
+
+If [gnuplot](http://www.gnuplot.info/) is installed, Criterion.rs can generate
+an HTML report displaying the results of the benchmark under
+`target/criterion/report/index.html`.
+
+Result of doing 100 random IP lookups:
+
+![](/assets/pdf_small.svg)
+
 ## Contributing ##
 
 Contributions welcome! Please fork the repository and open a pull request

--- a/assets/pdf_small.svg
+++ b/assets/pdf_small.svg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"  standalone="no"?>
+<svg 
+ viewBox="0 0 450 300"
+ xmlns="http://www.w3.org/2000/svg"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+>
+
+<title>Gnuplot</title>
+<desc>Produced by GNUPLOT 5.2 patchlevel 7 </desc>
+
+<g id="gnuplot_canvas">
+
+<rect x="0" y="0" width="450" height="300" fill="none"/>
+<defs>
+
+	<circle id='gpDot' r='0.5' stroke-width='0.5' stroke='currentColor'/>
+	<path id='gpPt0' stroke-width='0.222' stroke='currentColor' d='M-1,0 h2 M0,-1 v2'/>
+	<path id='gpPt1' stroke-width='0.222' stroke='currentColor' d='M-1,-1 L1,1 M1,-1 L-1,1'/>
+	<path id='gpPt2' stroke-width='0.222' stroke='currentColor' d='M-1,0 L1,0 M0,-1 L0,1 M-1,-1 L1,1 M-1,1 L1,-1'/>
+	<rect id='gpPt3' stroke-width='0.222' stroke='currentColor' x='-1' y='-1' width='2' height='2'/>
+	<rect id='gpPt4' stroke-width='0.222' stroke='currentColor' fill='currentColor' x='-1' y='-1' width='2' height='2'/>
+	<circle id='gpPt5' stroke-width='0.222' stroke='currentColor' cx='0' cy='0' r='1'/>
+	<use xlink:href='#gpPt5' id='gpPt6' fill='currentColor' stroke='none'/>
+	<path id='gpPt7' stroke-width='0.222' stroke='currentColor' d='M0,-1.33 L-1.33,0.67 L1.33,0.67 z'/>
+	<use xlink:href='#gpPt7' id='gpPt8' fill='currentColor' stroke='none'/>
+	<use xlink:href='#gpPt7' id='gpPt9' stroke='currentColor' transform='rotate(180)'/>
+	<use xlink:href='#gpPt9' id='gpPt10' fill='currentColor' stroke='none'/>
+	<use xlink:href='#gpPt3' id='gpPt11' stroke='currentColor' transform='rotate(45)'/>
+	<use xlink:href='#gpPt11' id='gpPt12' fill='currentColor' stroke='none'/>
+	<path id='gpPt13' stroke-width='0.222' stroke='currentColor' d='M0,1.330 L1.265,0.411 L0.782,-1.067 L-0.782,-1.076 L-1.265,0.411 z'/>
+	<use xlink:href='#gpPt13' id='gpPt14' fill='currentColor' stroke='none'/>
+	<filter id='textbox' filterUnits='objectBoundingBox' x='0' y='0' height='1' width='1'>
+	  <feFlood flood-color='white' flood-opacity='1' result='bgnd'/>
+	  <feComposite in='SourceGraphic' in2='bgnd' operator='atop'/>
+	</filter>
+	<filter id='greybox' filterUnits='objectBoundingBox' x='0' y='0' height='1' width='1'>
+	  <feFlood flood-color='lightgrey' flood-opacity='1' result='grey'/>
+	  <feComposite in='SourceGraphic' in2='grey' operator='atop'/>
+	</filter>
+</defs>
+<g fill="none" color="white" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,242.4 L80.9,242.4  '/>	<g transform="translate(63.6,246.3)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Helvetica" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,217.1 L80.9,217.1  '/>	<g transform="translate(63.6,221.0)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Helvetica" > 0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,191.8 L80.9,191.8  '/>	<g transform="translate(63.6,195.7)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Helvetica" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,166.5 L80.9,166.5  '/>	<g transform="translate(63.6,170.4)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Helvetica" > 1.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,141.2 L80.9,141.2  '/>	<g transform="translate(63.6,145.1)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Helvetica" > 2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,115.9 L80.9,115.9  '/>	<g transform="translate(63.6,119.8)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Helvetica" > 2.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,90.6 L80.9,90.6  '/>	<g transform="translate(63.6,94.5)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Helvetica" > 3</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,65.3 L80.9,65.3  '/>	<g transform="translate(63.6,69.2)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Helvetica" > 3.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,40.0 L80.9,40.0  '/>	<g transform="translate(63.6,43.9)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Helvetica" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M82.6,242.4 L82.6,233.4  '/>	<g transform="translate(82.6,264.3)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Helvetica" > 2.9</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M136.1,242.4 L136.1,233.4  '/>	<g transform="translate(136.1,264.3)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Helvetica" > 3</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M189.7,242.4 L189.7,233.4  '/>	<g transform="translate(189.7,264.3)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Helvetica" > 3.1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M243.3,242.4 L243.3,233.4  '/>	<g transform="translate(243.3,264.3)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Helvetica" > 3.2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M296.8,242.4 L296.8,233.4  '/>	<g transform="translate(296.8,264.3)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Helvetica" > 3.3</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M350.4,242.4 L350.4,233.4  '/>	<g transform="translate(350.4,264.3)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Helvetica" > 3.4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M403.9,242.4 L403.9,233.4  '/>	<g transform="translate(403.9,264.3)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Helvetica" > 3.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,18.1 L71.9,242.4 L425.0,242.4 L425.0,18.1 L71.9,18.1 Z  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<g transform="translate(25.3,130.3) rotate(270)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Helvetica" >Density (a.u.)</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<g transform="translate(248.4,291.3)" stroke="none" fill="black" font-family="Helvetica" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Helvetica" >Average time (ms)</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+</g>
+	<g id="gnuplot_plot_1" ><title>PDF</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'rgb( 31, 120, 180)' fill-opacity = '0.250000' points = '71.9,241.8 72.6,241.8 73.3,241.7 74.0,241.7 74.7,241.6 75.4,241.6 76.1,241.5 76.9,241.5 77.6,241.4 78.3,241.3 79.0,241.3 79.7,241.2 80.4,241.1 81.1,241.0 81.8,240.9 82.5,240.9
+83.2,240.8 83.9,240.7 84.6,240.6 85.3,240.5 86.1,240.3 86.8,240.2 87.5,240.1 88.2,239.9 88.9,239.8 89.6,239.7 90.3,239.5 91.0,239.3 91.7,239.2 92.4,239.0 93.1,238.8 93.8,238.6
+94.5,238.4 95.3,238.2 96.0,237.9 96.7,237.7 97.4,237.4 98.1,237.2 98.8,236.9 99.5,236.6 100.2,236.3 100.9,236.0 101.6,235.7 102.3,235.3 103.0,235.0 103.7,234.6 104.5,234.2 105.2,233.8
+105.9,233.4 106.6,232.9 107.3,232.5 108.0,232.0 108.7,231.5 109.4,231.0 110.1,230.5 110.8,229.9 111.5,229.4 112.2,228.8 112.9,228.1 113.6,227.5 114.4,226.8 115.1,226.2 115.8,225.4 116.5,224.7
+117.2,224.0 117.9,223.2 118.6,222.4 119.3,221.5 120.0,220.6 120.7,219.8 121.4,218.8 122.1,217.9 122.8,216.9 123.6,215.9 124.3,214.9 125.0,213.8 125.7,212.7 126.4,211.5 127.1,210.4 127.8,209.2
+128.5,208.0 129.2,206.7 129.9,205.4 130.6,204.1 131.3,202.7 132.0,201.3 132.8,199.9 133.5,198.4 134.2,196.9 134.9,195.4 135.6,193.8 136.3,192.2 137.0,190.6 137.7,188.9 138.4,187.2 139.1,185.4
+139.8,183.7 140.5,181.9 141.2,180.0 142.0,178.1 142.7,176.2 143.4,174.3 144.1,172.3 144.8,170.3 145.5,168.3 146.2,166.2 146.9,164.1 147.6,162.0 148.3,159.8 149.0,157.6 149.7,155.4 150.4,153.2
+151.2,150.9 151.9,148.6 152.6,146.3 153.3,144.0 154.0,141.6 154.7,139.2 155.4,136.8 156.1,134.4 156.8,132.0 157.5,129.5 158.2,127.1 158.9,124.6 159.6,122.1 160.4,119.6 161.1,117.1 161.8,114.6
+162.5,112.1 163.2,109.6 163.9,107.1 164.6,104.6 165.3,102.1 166.0,99.6 166.7,97.0 167.4,94.6 168.1,92.1 168.8,89.6 169.6,87.1 170.3,84.7 171.0,82.3 171.7,79.8 172.4,77.4 173.1,75.1
+173.8,72.7 174.5,70.4 175.2,68.1 175.9,65.9 176.6,63.6 177.3,61.5 178.0,59.3 178.7,57.2 179.5,55.1 180.2,53.1 180.9,51.1 181.6,49.1 182.3,47.2 183.0,45.4 183.7,43.6 184.4,41.8
+185.1,40.1 185.8,38.5 186.5,36.9 187.2,35.3 187.9,33.9 188.7,32.5 189.4,31.1 190.1,29.8 190.8,28.6 191.5,27.4 192.2,26.3 192.9,25.3 193.6,24.3 194.3,23.4 195.0,22.6 195.7,21.8
+196.4,21.2 197.1,20.5 197.9,20.0 198.6,19.5 199.3,19.1 200.0,18.7 200.7,18.5 201.4,18.3 202.1,18.2 202.8,18.1 203.5,18.1 204.2,18.2 204.9,18.3 205.6,18.6 206.3,18.9 207.1,19.2
+207.8,19.6 208.5,20.1 209.2,20.7 209.9,21.3 210.6,22.0 211.3,22.7 212.0,23.5 212.7,24.4 213.4,25.3 214.1,26.3 214.8,27.3 215.5,28.4 216.3,29.5 217.0,30.7 217.7,32.0 218.4,33.2
+219.1,34.6 219.8,36.0 220.5,37.4 221.2,38.8 221.9,40.3 222.6,41.9 223.3,43.4 224.0,45.0 224.7,46.6 225.5,48.3 226.2,50.0 226.9,51.7 227.6,53.4 228.3,55.2 229.0,57.0 229.7,58.8
+230.4,60.6 231.1,62.4 231.8,64.2 232.5,66.1 233.2,67.9 233.9,69.8 234.7,71.6 235.4,73.5 236.1,75.4 236.8,77.2 237.5,79.1 238.2,80.9 238.9,82.8 239.6,84.6 240.3,86.4 241.0,88.2
+241.7,90.0 242.4,91.8 243.1,93.6 243.9,95.4 244.6,97.1 245.3,98.8 246.0,100.5 246.7,102.2 247.4,103.8 248.1,105.5 248.8,107.1 249.5,108.6 250.2,110.2 250.9,111.7 251.6,113.2 252.3,114.7
+253.0,116.1 253.8,117.5 254.5,118.9 255.2,120.2 255.9,121.5 256.6,122.8 257.3,124.0 258.0,125.2 258.7,126.4 259.4,127.5 260.1,128.6 260.8,129.7 261.5,130.7 262.2,131.7 263.0,132.7 263.7,133.7
+264.4,134.6 265.1,135.4 265.8,136.3 266.5,137.1 267.2,137.8 267.9,138.6 268.6,139.3 269.3,140.0 270.0,140.6 270.7,141.2 271.4,141.8 272.2,142.4 272.9,142.9 273.6,143.4 274.3,143.9 275.0,144.3
+275.7,144.7 276.4,145.1 277.1,145.5 277.8,145.9 278.5,146.2 279.2,146.5 279.9,146.8 280.6,147.1 281.4,147.3 282.1,147.5 282.8,147.8 283.5,148.0 284.2,148.1 284.9,148.3 285.6,148.5 286.3,148.6
+287.0,148.8 287.7,148.9 288.4,149.0 289.1,149.1 289.8,149.2 290.6,149.3 291.3,149.4 292.0,149.5 292.7,149.6 293.4,149.6 294.1,149.7 294.8,149.8 295.5,149.9 296.2,150.0 296.9,150.0 297.6,150.1
+298.3,150.2 299.0,150.3 299.8,150.4 300.5,150.5 301.2,150.6 301.9,150.8 302.6,150.9 303.3,151.0 304.0,151.2 304.7,151.4 305.4,151.5 306.1,151.7 306.8,151.9 307.5,152.1 308.2,152.4 309.0,152.6
+309.7,152.9 310.4,153.1 311.1,153.4 311.8,153.7 312.5,154.0 313.2,154.4 313.9,154.7 314.6,155.1 315.3,155.5 316.0,155.9 316.7,156.3 317.4,156.8 318.2,157.2 318.9,157.7 319.6,158.2 320.3,158.7
+321.0,159.3 321.7,159.8 322.4,160.4 323.1,161.0 323.8,161.6 324.5,162.2 325.2,162.8 325.9,163.5 326.6,164.2 327.3,164.9 328.1,165.6 328.8,166.3 329.5,167.0 330.2,167.8 330.9,168.6 331.6,169.4
+332.3,170.2 333.0,171.0 333.7,171.8 334.4,172.6 335.1,173.5 335.8,174.4 336.5,175.2 337.3,176.1 338.0,177.0 338.7,177.9 339.4,178.8 340.1,179.7 340.8,180.7 341.5,181.6 342.2,182.6 342.9,183.5
+343.6,184.5 344.3,185.4 345.0,186.4 345.7,187.3 346.5,188.3 347.2,189.3 347.9,190.2 348.6,191.2 349.3,192.2 350.0,193.1 350.7,194.1 351.4,195.1 352.1,196.0 352.8,197.0 353.5,197.9 354.2,198.9
+354.9,199.8 355.7,200.8 356.4,201.7 357.1,202.6 357.8,203.6 358.5,204.5 359.2,205.4 359.9,206.3 360.6,207.2 361.3,208.1 362.0,208.9 362.7,209.8 363.4,210.6 364.1,211.5 364.9,212.3 365.6,213.1
+366.3,213.9 367.0,214.7 367.7,215.5 368.4,216.3 369.1,217.0 369.8,217.8 370.5,218.5 371.2,219.2 371.9,220.0 372.6,220.6 373.3,221.3 374.1,222.0 374.8,222.6 375.5,223.3 376.2,223.9 376.9,224.5
+377.6,225.1 378.3,225.7 379.0,226.3 379.7,226.8 380.4,227.4 381.1,227.9 381.8,228.4 382.5,228.9 383.3,229.4 384.0,229.9 384.7,230.4 385.4,230.8 386.1,231.3 386.8,231.7 387.5,232.1 388.2,232.5
+388.9,232.9 389.6,233.3 390.3,233.7 391.0,234.0 391.7,234.4 392.4,234.7 393.2,235.0 393.9,235.3 394.6,235.6 395.3,235.9 396.0,236.2 396.7,236.5 397.4,236.7 398.1,237.0 398.8,237.2 399.5,237.5
+400.2,237.7 400.9,237.9 401.6,238.1 402.4,238.3 403.1,238.5 403.8,238.7 404.5,238.9 405.2,239.0 405.9,239.2 406.6,239.4 407.3,239.5 408.0,239.7 408.7,239.8 409.4,239.9 410.1,240.0 410.8,240.2
+411.6,240.3 412.3,240.4 413.0,240.5 413.7,240.6 414.4,240.7 415.1,240.8 415.8,240.9 416.5,241.0 417.2,241.0 417.9,241.1 418.6,241.2 419.3,241.3 420.0,241.3 420.8,241.4 421.5,241.4 422.2,241.5
+422.9,241.5 423.6,241.6 424.3,241.6 425.0,241.7 425.0,242.4 424.3,242.4 423.6,242.4 422.9,242.4 422.2,242.4 421.5,242.4 420.8,242.4 420.0,242.4 419.3,242.4 418.6,242.4 417.9,242.4 417.2,242.4
+416.5,242.4 415.8,242.4 415.1,242.4 414.4,242.4 413.7,242.4 413.0,242.4 412.3,242.4 411.6,242.4 410.8,242.4 410.1,242.4 409.4,242.4 408.7,242.4 408.0,242.4 407.3,242.4 406.6,242.4 405.9,242.4
+405.2,242.4 404.5,242.4 403.8,242.4 403.1,242.4 402.4,242.4 401.6,242.4 400.9,242.4 400.2,242.4 399.5,242.4 398.8,242.4 398.1,242.4 397.4,242.4 396.7,242.4 396.0,242.4 395.3,242.4 394.6,242.4
+393.9,242.4 393.2,242.4 392.4,242.4 391.7,242.4 391.0,242.4 390.3,242.4 389.6,242.4 388.9,242.4 388.2,242.4 387.5,242.4 386.8,242.4 386.1,242.4 385.4,242.4 384.7,242.4 384.0,242.4 383.3,242.4
+382.5,242.4 381.8,242.4 381.1,242.4 380.4,242.4 379.7,242.4 379.0,242.4 378.3,242.4 377.6,242.4 376.9,242.4 376.2,242.4 375.5,242.4 374.8,242.4 374.1,242.4 373.3,242.4 372.6,242.4 371.9,242.4
+371.2,242.4 370.5,242.4 369.8,242.4 369.1,242.4 368.4,242.4 367.7,242.4 367.0,242.4 366.3,242.4 365.6,242.4 364.9,242.4 364.1,242.4 363.4,242.4 362.7,242.4 362.0,242.4 361.3,242.4 360.6,242.4
+359.9,242.4 359.2,242.4 358.5,242.4 357.8,242.4 357.1,242.4 356.4,242.4 355.7,242.4 354.9,242.4 354.2,242.4 353.5,242.4 352.8,242.4 352.1,242.4 351.4,242.4 350.7,242.4 350.0,242.4 349.3,242.4
+348.6,242.4 347.9,242.4 347.2,242.4 346.5,242.4 345.7,242.4 345.0,242.4 344.3,242.4 343.6,242.4 342.9,242.4 342.2,242.4 341.5,242.4 340.8,242.4 340.1,242.4 339.4,242.4 338.7,242.4 338.0,242.4
+337.3,242.4 336.5,242.4 335.8,242.4 335.1,242.4 334.4,242.4 333.7,242.4 333.0,242.4 332.3,242.4 331.6,242.4 330.9,242.4 330.2,242.4 329.5,242.4 328.8,242.4 328.1,242.4 327.3,242.4 326.6,242.4
+325.9,242.4 325.2,242.4 324.5,242.4 323.8,242.4 323.1,242.4 322.4,242.4 321.7,242.4 321.0,242.4 320.3,242.4 319.6,242.4 318.9,242.4 318.2,242.4 317.4,242.4 316.7,242.4 316.0,242.4 315.3,242.4
+314.6,242.4 313.9,242.4 313.2,242.4 312.5,242.4 311.8,242.4 311.1,242.4 310.4,242.4 309.7,242.4 309.0,242.4 308.2,242.4 307.5,242.4 306.8,242.4 306.1,242.4 305.4,242.4 304.7,242.4 304.0,242.4
+303.3,242.4 302.6,242.4 301.9,242.4 301.2,242.4 300.5,242.4 299.8,242.4 299.0,242.4 298.3,242.4 297.6,242.4 296.9,242.4 296.2,242.4 295.5,242.4 294.8,242.4 294.1,242.4 293.4,242.4 292.7,242.4
+292.0,242.4 291.3,242.4 290.6,242.4 289.8,242.4 289.1,242.4 288.4,242.4 287.7,242.4 287.0,242.4 286.3,242.4 285.6,242.4 284.9,242.4 284.2,242.4 283.5,242.4 282.8,242.4 282.1,242.4 281.4,242.4
+280.6,242.4 279.9,242.4 279.2,242.4 278.5,242.4 277.8,242.4 277.1,242.4 276.4,242.4 275.7,242.4 275.0,242.4 274.3,242.4 273.6,242.4 272.9,242.4 272.2,242.4 271.4,242.4 270.7,242.4 270.0,242.4
+269.3,242.4 268.6,242.4 267.9,242.4 267.2,242.4 266.5,242.4 265.8,242.4 265.1,242.4 264.4,242.4 263.7,242.4 263.0,242.4 262.2,242.4 261.5,242.4 260.8,242.4 260.1,242.4 259.4,242.4 258.7,242.4
+258.0,242.4 257.3,242.4 256.6,242.4 255.9,242.4 255.2,242.4 254.5,242.4 253.8,242.4 253.0,242.4 252.3,242.4 251.6,242.4 250.9,242.4 250.2,242.4 249.5,242.4 248.8,242.4 248.1,242.4 247.4,242.4
+246.7,242.4 246.0,242.4 245.3,242.4 244.6,242.4 243.9,242.4 243.1,242.4 242.4,242.4 241.7,242.4 241.0,242.4 240.3,242.4 239.6,242.4 238.9,242.4 238.2,242.4 237.5,242.4 236.8,242.4 236.1,242.4
+235.4,242.4 234.7,242.4 233.9,242.4 233.2,242.4 232.5,242.4 231.8,242.4 231.1,242.4 230.4,242.4 229.7,242.4 229.0,242.4 228.3,242.4 227.6,242.4 226.9,242.4 226.2,242.4 225.5,242.4 224.7,242.4
+224.0,242.4 223.3,242.4 222.6,242.4 221.9,242.4 221.2,242.4 220.5,242.4 219.8,242.4 219.1,242.4 218.4,242.4 217.7,242.4 217.0,242.4 216.3,242.4 215.5,242.4 214.8,242.4 214.1,242.4 213.4,242.4
+212.7,242.4 212.0,242.4 211.3,242.4 210.6,242.4 209.9,242.4 209.2,242.4 208.5,242.4 207.8,242.4 207.1,242.4 206.3,242.4 205.6,242.4 204.9,242.4 204.2,242.4 203.5,242.4 202.8,242.4 202.1,242.4
+201.4,242.4 200.7,242.4 200.0,242.4 199.3,242.4 198.6,242.4 197.9,242.4 197.1,242.4 196.4,242.4 195.7,242.4 195.0,242.4 194.3,242.4 193.6,242.4 192.9,242.4 192.2,242.4 191.5,242.4 190.8,242.4
+190.1,242.4 189.4,242.4 188.7,242.4 187.9,242.4 187.2,242.4 186.5,242.4 185.8,242.4 185.1,242.4 184.4,242.4 183.7,242.4 183.0,242.4 182.3,242.4 181.6,242.4 180.9,242.4 180.2,242.4 179.5,242.4
+178.7,242.4 178.0,242.4 177.3,242.4 176.6,242.4 175.9,242.4 175.2,242.4 174.5,242.4 173.8,242.4 173.1,242.4 172.4,242.4 171.7,242.4 171.0,242.4 170.3,242.4 169.6,242.4 168.8,242.4 168.1,242.4
+167.4,242.4 166.7,242.4 166.0,242.4 165.3,242.4 164.6,242.4 163.9,242.4 163.2,242.4 162.5,242.4 161.8,242.4 161.1,242.4 160.4,242.4 159.6,242.4 158.9,242.4 158.2,242.4 157.5,242.4 156.8,242.4
+156.1,242.4 155.4,242.4 154.7,242.4 154.0,242.4 153.3,242.4 152.6,242.4 151.9,242.4 151.2,242.4 150.4,242.4 149.7,242.4 149.0,242.4 148.3,242.4 147.6,242.4 146.9,242.4 146.2,242.4 145.5,242.4
+144.8,242.4 144.1,242.4 143.4,242.4 142.7,242.4 142.0,242.4 141.2,242.4 140.5,242.4 139.8,242.4 139.1,242.4 138.4,242.4 137.7,242.4 137.0,242.4 136.3,242.4 135.6,242.4 134.9,242.4 134.2,242.4
+133.5,242.4 132.8,242.4 132.0,242.4 131.3,242.4 130.6,242.4 129.9,242.4 129.2,242.4 128.5,242.4 127.8,242.4 127.1,242.4 126.4,242.4 125.7,242.4 125.0,242.4 124.3,242.4 123.6,242.4 122.8,242.4
+122.1,242.4 121.4,242.4 120.7,242.4 120.0,242.4 119.3,242.4 118.6,242.4 117.9,242.4 117.2,242.4 116.5,242.4 115.8,242.4 115.1,242.4 114.4,242.4 113.6,242.4 112.9,242.4 112.2,242.4 111.5,242.4
+110.8,242.4 110.1,242.4 109.4,242.4 108.7,242.4 108.0,242.4 107.3,242.4 106.6,242.4 105.9,242.4 105.2,242.4 104.5,242.4 103.7,242.4 103.0,242.4 102.3,242.4 101.6,242.4 100.9,242.4 100.2,242.4
+99.5,242.4 98.8,242.4 98.1,242.4 97.4,242.4 96.7,242.4 96.0,242.4 95.3,242.4 94.5,242.4 93.8,242.4 93.1,242.4 92.4,242.4 91.7,242.4 91.0,242.4 90.3,242.4 89.6,242.4 88.9,242.4
+88.2,242.4 87.5,242.4 86.8,242.4 86.1,242.4 85.3,242.4 84.6,242.4 83.9,242.4 83.2,242.4 82.5,242.4 81.8,242.4 81.1,242.4 80.4,242.4 79.7,242.4 79.0,242.4 78.3,242.4 77.6,242.4
+76.9,242.4 76.1,242.4 75.4,242.4 74.7,242.4 74.0,242.4 73.3,242.4 72.6,242.4 71.9,242.4 '/>
+	</g>
+</g>
+	</g>
+	<g id="gnuplot_plot_2" ><title>Mean</title>
+<g fill="none" color="white" stroke="rgb( 31, 120, 180)" stroke-width="2.00" stroke-linecap="butt" stroke-linejoin="miter">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='rgb( 31, 120, 180)'  d='M232.2,242.4 L232.2,81.3  '/></g>
+	</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="butt" stroke-linejoin="miter">
+</g>
+<g fill="none" color="black" stroke="black" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+	<path stroke='black'  d='M71.9,18.1 L71.9,242.4 L425.0,242.4 L425.0,18.1 L71.9,18.1 Z  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt" stroke-linejoin="miter">
+</g>
+</g>
+</svg>
+

--- a/benches/lookup.rs
+++ b/benches/lookup.rs
@@ -1,0 +1,66 @@
+#[macro_use]
+extern crate criterion;
+extern crate fake;
+extern crate maxminddb;
+extern crate rayon;
+
+use criterion::black_box;
+use criterion::Criterion;
+use fake::faker::internet::raw::*;
+use fake::locales::EN;
+use fake::Fake;
+use maxminddb::geoip2;
+use rayon::prelude::*;
+
+use std::net::IpAddr;
+use std::str::FromStr;
+
+// Generate `count` IPv4 addresses
+pub fn generate_ipv4(count: u64) -> Vec<IpAddr> {
+    let mut ips = Vec::new();
+    for _i in 0..count {
+        let val: String = IPv4(EN).fake();
+        let ip: IpAddr = FromStr::from_str(&val).unwrap();
+        ips.push(ip);
+    }
+    ips
+}
+
+// Single-threaded
+pub fn bench_maxminddb(ips: &Vec<IpAddr>, reader: &maxminddb::Reader<Vec<u8>>) {
+    ips.iter().for_each(|ip| {
+        let city: Result<geoip2::City, _> = reader.lookup(*ip);
+    });
+}
+
+// Using rayon for parallel execution
+pub fn bench_par_maxminddb(ips: &Vec<IpAddr>, reader: &maxminddb::Reader<Vec<u8>>) {
+    ips.par_iter().for_each(|ip| {
+        let city: Result<geoip2::City, _> = reader.lookup(*ip);
+    });
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let ips = generate_ipv4(100);
+    let reader = maxminddb::Reader::open_readfile("GeoIP2-City.mmdb").unwrap();
+
+    c.bench_function("maxminddb", |b| b.iter(|| bench_maxminddb(&ips, &reader)));
+}
+
+pub fn criterion_par_benchmark(c: &mut Criterion) {
+    let ips = generate_ipv4(100);
+    let reader = maxminddb::Reader::open_readfile("GeoIP2-City.mmdb").unwrap();
+
+    c.bench_function("maxminddb_par", |b| {
+        b.iter(|| bench_par_maxminddb(&ips, &reader))
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10);
+
+    targets = criterion_benchmark, criterion_par_benchmark
+}
+criterion_main!(benches);


### PR DESCRIPTION
This adds the benchmarks from
https://github.com/mre/maxminddb-rust-bench/
to the main repo.
It is a quick way to (manually) test for performance
regressions when doing bigger changes.
We might want to add those tests to CI
at some point.

Closes #22 