### PR TITLE
Ignore GeoLite DBs by extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 *.so
 *.sw?
 Cargo.lock
-GeoLite2-City.mmdb
+/*.mmdb
 target
-GeoIP2-City.mmdb


### PR DESCRIPTION
They seem to change names from time to time, but not the file suffix.