### PR TITLE
Performance enhancements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 [features]
 default = []
 mmap = ["memmap"]
+unsafe-str-decode = []
 
 [lib]
 name ="maxminddb"

--- a/src/maxminddb/geoip2.rs
+++ b/src/maxminddb/geoip2.rs
@@ -1,40 +1,42 @@
 /// GeoIP2 Country record
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct Country {
-    pub continent: Option<model::Continent>,
-    pub country: Option<model::Country>,
-    pub registered_country: Option<model::Country>,
-    pub represented_country: Option<model::RepresentedCountry>,
+pub struct Country<'a> {
+    #[serde(borrow)]
+    pub continent: Option<model::Continent<'a>>,
+    pub country: Option<model::Country<'a>>,
+    pub registered_country: Option<model::Country<'a>>,
+    pub represented_country: Option<model::RepresentedCountry<'a>>,
     pub traits: Option<model::Traits>,
 }
 
 /// GeoIP2 City record
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct City {
-    pub city: Option<model::City>,
-    pub continent: Option<model::Continent>,
-    pub country: Option<model::Country>,
-    pub location: Option<model::Location>,
-    pub postal: Option<model::Postal>,
-    pub registered_country: Option<model::Country>,
-    pub represented_country: Option<model::RepresentedCountry>,
-    pub subdivisions: Option<Vec<model::Subdivision>>,
+pub struct City<'a> {
+    pub city: Option<model::City<'a>>,
+    #[serde(borrow)]
+    pub continent: Option<model::Continent<'a>>,
+    pub country: Option<model::Country<'a>>,
+    pub location: Option<model::Location<'a>>,
+    pub postal: Option<model::Postal<'a>>,
+    pub registered_country: Option<model::Country<'a>>,
+    pub represented_country: Option<model::RepresentedCountry<'a>>,
+    pub subdivisions: Option<Vec<model::Subdivision<'a>>>,
     pub traits: Option<model::Traits>,
 }
 
 /// GeoIP2 ISP record
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct Isp {
+pub struct Isp<'a> {
     pub autonomous_system_number: Option<u32>,
-    pub autonomous_system_organization: Option<String>,
-    pub isp: Option<String>,
-    pub organization: Option<String>,
+    pub autonomous_system_organization: Option<&'a str>,
+    pub isp: Option<&'a str>,
+    pub organization: Option<&'a str>,
 }
 
 /// GeoIP2 Connection-Type record
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct ConnectionType {
-    pub connection_type: Option<String>,
+pub struct ConnectionType<'a> {
+    pub connection_type: Option<&'a str>,
 }
 
 /// GeoIP2 Anonymous Ip record
@@ -56,66 +58,67 @@ pub struct DensityIncome {
 
 /// GeoIP2 Domain record
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct Domain {
-    pub domain: Option<String>,
+pub struct Domain<'a> {
+    pub domain: Option<&'a str>,
 }
 
 /// GeoIP2 Asn record
 #[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct Asn {
+pub struct Asn<'a> {
     pub autonomous_system_number: Option<u32>,
-    pub autonomous_system_organization: Option<String>,
+    pub autonomous_system_organization: Option<&'a str>,
 }
 
 pub mod model {
     use std::collections::BTreeMap;
 
     #[derive(Deserialize, Serialize, Clone, Debug)]
-    pub struct City {
+    pub struct City<'a> {
         pub geoname_id: Option<u32>,
-        pub names: Option<BTreeMap<String, String>>,
+        #[serde(borrow)]
+        pub names: Option<BTreeMap<&'a str, &'a str>>,
     }
 
     #[derive(Deserialize, Serialize, Clone, Debug)]
-    pub struct Continent {
-        pub code: Option<String>,
+    pub struct Continent<'a> {
+        pub code: Option<&'a str>,
         pub geoname_id: Option<u32>,
-        pub names: Option<BTreeMap<String, String>>,
+        pub names: Option<BTreeMap<&'a str, &'a str>>,
     }
 
     #[derive(Deserialize, Serialize, Clone, Debug)]
-    pub struct Country {
+    pub struct Country<'a> {
         pub geoname_id: Option<u32>,
         pub is_in_european_union: Option<bool>,
-        pub iso_code: Option<String>,
-        pub names: Option<BTreeMap<String, String>>,
+        pub iso_code: Option<&'a str>,
+        pub names: Option<BTreeMap<&'a str, &'a str>>,
     }
 
     #[derive(Deserialize, Serialize, Clone, Debug)]
-    pub struct Location {
+    pub struct Location<'a> {
         pub latitude: Option<f64>,
         pub longitude: Option<f64>,
         pub metro_code: Option<u16>,
-        pub time_zone: Option<String>,
+        pub time_zone: Option<&'a str>,
     }
 
     #[derive(Deserialize, Serialize, Clone, Debug)]
-    pub struct Postal {
-        pub code: Option<String>,
+    pub struct Postal<'a> {
+        pub code: Option<&'a str>,
     }
 
     #[derive(Deserialize, Serialize, Clone, Debug)]
-    pub struct RepresentedCountry {
+    pub struct RepresentedCountry<'a> {
         pub geoname_id: Option<u32>,
-        pub iso_code: Option<String>,
-        pub names: Option<BTreeMap<String, String>>, // pub type: Option<String>,
+        pub iso_code: Option<&'a str>,
+        pub names: Option<BTreeMap<&'a str, &'a str>>, // pub type: Option<&'a str>,
     }
 
     #[derive(Deserialize, Serialize, Clone, Debug)]
-    pub struct Subdivision {
+    pub struct Subdivision<'a> {
         pub geoname_id: Option<u32>,
-        pub iso_code: Option<String>,
-        pub names: Option<BTreeMap<String, String>>,
+        pub iso_code: Option<&'a str>,
+        pub names: Option<BTreeMap<&'a str, &'a str>>,
     }
 
     #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -98,7 +98,7 @@ struct BinaryDecoder<T: AsRef<[u8]>> {
 
 impl<T: AsRef<[u8]>> BinaryDecoder<T> {
     fn decode_array(&self, size: usize, offset: usize) -> BinaryDecodeResult<decoder::DataRecord> {
-        let mut array = Vec::new();
+        let mut array = Vec::with_capacity(size);
         let mut new_offset = offset;
 
         for _ in 0..size {
@@ -256,7 +256,7 @@ impl<T: AsRef<[u8]>> BinaryDecoder<T> {
     }
 
     fn decode_map(&self, size: usize, offset: usize) -> BinaryDecodeResult<decoder::DataRecord> {
-        let mut values = Box::new(BTreeMap::new());
+        let mut values = BTreeMap::new();
         let mut new_offset = offset;
 
         for _ in 0..size {
@@ -317,7 +317,7 @@ impl<T: AsRef<[u8]>> BinaryDecoder<T> {
         let new_offset: usize = offset + size;
         let bytes = &self.buf.as_ref()[offset..new_offset];
         match from_utf8(bytes) {
-            Ok(v) => (Ok(decoder::DataRecord::String(v.to_owned())), new_offset),
+            Ok(v) => (Ok(decoder::DataRecord::String(v)), new_offset),
             Err(_) => (
                 Err(MaxMindDBError::InvalidDatabaseError(
                     "error decoding string".to_owned(),
@@ -500,7 +500,7 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
     /// let city: geoip2::City = reader.lookup(ip).unwrap();
     /// print!("{:?}", city);
     /// ```
-    pub fn lookup<T>(&self, address: IpAddr) -> Result<T, MaxMindDBError>
+    pub fn lookup<T>(&'de self, address: IpAddr) -> Result<T, MaxMindDBError>
     where
         T: Deserialize<'de>,
     {

--- a/src/maxminddb/reader_test.rs
+++ b/src/maxminddb/reader_test.rs
@@ -201,7 +201,7 @@ fn test_lookup_city() {
 
     let iso_code = city.country.and_then(|cy| cy.iso_code);
 
-    assert_eq!(iso_code, Some("SE".to_owned()));
+    assert_eq!(iso_code, Some("SE"));
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn test_lookup_country() {
     let country: Country = reader.lookup(ip).unwrap();
     let country: super::geoip2::model::Country = country.country.unwrap();
 
-    assert_eq!(country.iso_code, Some("SE".to_owned()));
+    assert_eq!(country.iso_code, Some("SE"));
     assert_eq!(country.is_in_european_union, Some(true));
 }
 
@@ -233,10 +233,7 @@ fn test_lookup_connection_type() {
     let ip: IpAddr = FromStr::from_str("96.1.20.112").unwrap();
     let connection_type: ConnectionType = reader.lookup(ip).unwrap();
 
-    assert_eq!(
-        connection_type.connection_type,
-        Some("Cable/DSL".to_owned())
-    );
+    assert_eq!(connection_type.connection_type, Some("Cable/DSL"));
 }
 
 #[test]
@@ -286,7 +283,7 @@ fn test_lookup_domain() {
     let ip: IpAddr = FromStr::from_str("66.92.80.123").unwrap();
     let domain: Domain = reader.lookup(ip).unwrap();
 
-    assert_eq!(domain.domain, Some("speakeasy.net".to_owned()));
+    assert_eq!(domain.domain, Some("speakeasy.net"));
 }
 
 #[test]
@@ -302,8 +299,8 @@ fn test_lookup_isp() {
     let isp: Isp = reader.lookup(ip).unwrap();
 
     assert_eq!(isp.autonomous_system_number, Some(7018));
-    assert_eq!(isp.isp, Some("AT&T Services".to_owned()));
-    assert_eq!(isp.organization, Some("AT&T Worldnet Services".to_owned()));
+    assert_eq!(isp.isp, Some("AT&T Services"));
+    assert_eq!(isp.organization, Some("AT&T Worldnet Services"));
 }
 
 #[test]
@@ -319,10 +316,7 @@ fn test_lookup_asn() {
     let asn: Asn = reader.lookup(ip).unwrap();
 
     assert_eq!(asn.autonomous_system_number, Some(1221));
-    assert_eq!(
-        asn.autonomous_system_organization,
-        Some("Telstra Pty Ltd".to_owned())
-    );
+    assert_eq!(asn.autonomous_system_organization, Some("Telstra Pty Ltd"));
 }
 
 fn check_metadata<T: AsRef<[u8]>>(reader: &Reader<T>, ip_version: usize, record_size: usize) {


### PR DESCRIPTION
This PR adds performance enhancements to maxminddb-rust.  It is broken into three commits.

![2020-06-06-225255_484x543_scrot](https://user-images.githubusercontent.com/2483388/83961516-b4a44e80-a848-11ea-82d4-8efbf430c3fa.png)

Checking out upstream/master, `cargo bench` gives me the following:

```
     Running target/release/deps/lookup-8016720bc456e2d4
maxminddb               time:   [2.1721 ms 2.1730 ms 2.1741 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

maxminddb_par           time:   [190.76 us 192.28 us 193.60 us]
```

## 1. Reduce internal allocations

This commit mostly modifies DataRecord to use &str instead of String, and comes with some decent performance improvements:

```
     Running target/release/deps/lookup-8016720bc456e2d4
maxminddb               time:   [1.9167 ms 1.9180 ms 1.9208 ms]
                        change: [-11.884% -11.651% -11.283%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

maxminddb_par           time:   [163.56 us 165.95 us 168.37 us]
                        change: [-15.047% -13.843% -12.652%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
```

## 2. Add opt-in unsafe string decode feature

This commit adds a new opt-in feature that skips utf8 validation, an intensive operation that may not be needed in performance-critical environments where the maxminddb is trusted.  When benched with the feature turned on (vs the previous commit):

```
maxminddb               time:   [1.8062 ms 1.8103 ms 1.8175 ms]
                        change: [-5.9584% -5.4895% -5.0301%] (p = 0.00 < 0.05)
                        Performance has improved.

maxminddb_par           time:   [146.40 us 147.32 us 148.30 us]
                        change: [-11.260% -9.8868% -8.3574%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## 3. Use &str in returned types

This commit changes the API completely.  All Strings in the geoip structs are now returned as references.  However, the results are great if ownership is not needed (vs the previous commit and with the unsafe-str-decode feature turned on):

```
maxminddb               time:   [1.2839 ms 1.3063 ms 1.3352 ms]
                        change: [-29.340% -28.380% -27.321%] (p = 0.00 < 0.05)
                        Performance has improved.

maxminddb_par           time:   [119.04 us 120.71 us 122.97 us]
                        change: [-19.156% -16.821% -14.017%] (p = 0.00 < 0.05)
                        Performance has improved.
```

While the benchmarks can vary, a project I'm working on, which uses this as a backend, goes from handling 200,000 requests per second to over 250,000 (25%).