### PR TITLE
Drastically improve deserialization speed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ path = "src/maxminddb/lib.rs"
 
 [dependencies]
 log = "0.4"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 memmap = { version = "0.7.0", optional = true }
 
 [dev-dependencies]

--- a/src/maxminddb/decoder.rs
+++ b/src/maxminddb/decoder.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 
+use log::debug;
 use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde::forward_to_deserialize_any;
 
 use super::MaxMindDBError;
 use super::MaxMindDBError::DecodingError;

--- a/src/maxminddb/geoip2.rs
+++ b/src/maxminddb/geoip2.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// GeoIP2 Country record
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Country<'a> {
@@ -70,6 +72,7 @@ pub struct Asn<'a> {
 }
 
 pub mod model {
+    use serde::{Deserialize, Serialize};
     use std::collections::BTreeMap;
 
     #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -1,36 +1,19 @@
-#![crate_name = "maxminddb"]
-#![deny(
-    trivial_casts,
-    trivial_numeric_casts,
-    unstable_features,
-    unused_import_braces
-)]
-
-#[macro_use]
-extern crate log;
-
-#[cfg(feature = "mmap")]
-extern crate memmap;
-
-#[macro_use]
-extern crate serde;
-
-#[macro_use]
-extern crate serde_derive;
+#![deny(trivial_casts, trivial_numeric_casts, unused_import_braces)]
 
 use std::collections::BTreeMap;
 use std::fmt::{self, Display, Formatter};
 use std::io;
 use std::net::IpAddr;
+use std::path::Path;
+
+use serde::{de, Deserialize};
 
 #[cfg(feature = "mmap")]
 use memmap::Mmap;
 #[cfg(feature = "mmap")]
 use memmap::MmapOptions;
-use serde::{de, Deserialize};
 #[cfg(feature = "mmap")]
 use std::fs::File;
-use std::path::Path;
 
 #[derive(Debug, PartialEq)]
 pub enum MaxMindDBError {

--- a/src/maxminddb/reader_test.rs
+++ b/src/maxminddb/reader_test.rs
@@ -24,10 +24,10 @@ fn test_decoder() {
     };
 
     #[derive(Deserialize, Debug)]
-    struct TestType {
+    struct TestType<'a> {
         array: Vec<u32>,
         boolean: bool,
-        bytes: Vec<u8>,
+        bytes: &'a [u8],
         double: f64,
         float: f32,
         int32: i32,
@@ -35,7 +35,7 @@ fn test_decoder() {
         uint16: u16,
         uint32: u32,
         uint64: u64,
-        uint128: Vec<u8>,
+        uint128: &'a [u8],
         utf8_string: String,
     }
 
@@ -85,7 +85,7 @@ fn test_broken_database() {
     let ip: IpAddr = FromStr::from_str("2001:220::").unwrap();
 
     #[derive(Deserialize, Debug)]
-    struct TestType;
+    struct TestType {}
     match r.lookup::<TestType>(ip) {
         Err(e) => assert_eq!(
             e,

--- a/src/maxminddb/reader_test.rs
+++ b/src/maxminddb/reader_test.rs
@@ -1,7 +1,9 @@
-use super::{MaxMindDBError, Reader};
-
 use std::net::IpAddr;
 use std::str::FromStr;
+
+use serde::Deserialize;
+
+use super::{MaxMindDBError, Reader};
 
 #[allow(clippy::float_cmp)]
 #[test]


### PR DESCRIPTION
This PR merges the previous DB and Serde decoder into just the Serde decoder. This improves performance at least by avoiding to have to keep our own element stack. I assume that Serde internally is also able to do some optimizations. Anyways, the results speak for themselves:

```
➜  maxminddb-rust git:(master) ✗ cargo bench
   Compiling maxminddb v0.15.0 (./maxminddb-rust)
    Finished bench [optimized] target(s) in 8.69s
     Running target/release/deps/maxminddb-6fa79ea948b683cf

running 15 tests
test reader_test::test_broken_database ... ignored
test reader_test::test_decoder ... ignored
test reader_test::test_lookup_annonymous_ip ... ignored
test reader_test::test_lookup_asn ... ignored
test reader_test::test_lookup_city ... ignored
test reader_test::test_lookup_connection_type ... ignored
test reader_test::test_lookup_country ... ignored
test reader_test::test_lookup_density_income ... ignored
test reader_test::test_lookup_domain ... ignored
test reader_test::test_lookup_isp ... ignored
test reader_test::test_missing_database ... ignored
test reader_test::test_non_database ... ignored
test reader_test::test_reader ... ignored
test reader_test::test_reader_readfile ... ignored
test tests::test_error_display ... ignored

test result: ok. 0 passed; 0 failed; 15 ignored; 0 measured; 0 filtered out

     Running target/release/deps/lookup-5c9e490b6fff5637
Gnuplot not found, using plotters backend
maxminddb               time:   [958.17 us 999.84 us 1.0335 ms]                      

maxminddb_par           time:   [177.46 us 186.50 us 192.61 us]                         

➜  maxminddb-rust git:(refactor/serde) ✗ cargo bench
   Compiling maxminddb v0.15.0 (./maxminddb-rust)
    Finished bench [optimized] target(s) in 14.54s
     Running target/release/deps/maxminddb-bfc41ab9aef5fa78

running 15 tests
test reader_test::test_broken_database ... ignored
test reader_test::test_decoder ... ignored
test reader_test::test_lookup_annonymous_ip ... ignored
test reader_test::test_lookup_asn ... ignored
test reader_test::test_lookup_city ... ignored
test reader_test::test_lookup_connection_type ... ignored
test reader_test::test_lookup_country ... ignored
test reader_test::test_lookup_density_income ... ignored
test reader_test::test_lookup_domain ... ignored
test reader_test::test_lookup_isp ... ignored
test reader_test::test_missing_database ... ignored
test reader_test::test_non_database ... ignored
test reader_test::test_reader ... ignored
test reader_test::test_reader_readfile ... ignored
test tests::test_error_display ... ignored

test result: ok. 0 passed; 0 failed; 15 ignored; 0 measured; 0 filtered out

     Running target/release/deps/lookup-1ec7f96f58896bf9
Gnuplot not found, using plotters backend
maxminddb               time:   [419.66 us 445.24 us 471.40 us]                     
                        change: [-55.656% -50.935% -44.929%] (p = 0.00 < 0.05)
                        Performance has improved.

maxminddb_par           time:   [104.27 us 108.92 us 111.34 us]                         
                        change: [-46.187% -42.664% -39.228%] (p = 0.00 < 0.05)
                        Performance has improved.
```

There _is_ a change with this (as can be seen from the tests) in that byte arrays cannot be deserialized into a Vec anymore (errors out because Serde's expecting a Seq but getting back borrowed bytes). I think this may be able to be supported by implementing deserialize_seq as well, but the current code structure doesn't lend itself particularly well. Considering the performance gains I thought it may be useful to get this merged as-is though, especially since it doesn't impact any of the exposed structs and even for custom struct its actually a less breaking change than the borrow-change from a while ago.

I've also taken the liberty to drop some of the old-style rust declarations that are no longer necessary.