### PR TITLE
refactor: Reduce the amount of code generated by shrinking generic methods

### DIFF
--- a/src/maxminddb/decoder.rs
+++ b/src/maxminddb/decoder.rs
@@ -54,7 +54,7 @@ impl<'de> Decoder<'de> {
         }
     }
 
-    fn decode_any<V: Visitor<'de>>(&mut self, visitor: V) -> DecodeResult<V::Value> {
+    fn size_and_type(&mut self) -> (usize, u8) {
         let ctrl_byte = self.eat_byte();
         let mut type_num = ctrl_byte >> 5;
         // Extended type
@@ -62,6 +62,11 @@ impl<'de> Decoder<'de> {
             type_num = self.eat_byte() + 7;
         }
         let size = self.size_from_ctrl_byte(ctrl_byte, type_num);
+        (size, type_num)
+    }
+
+    fn decode_any<V: Visitor<'de>>(&mut self, visitor: V) -> DecodeResult<V::Value> {
+        let (size, type_num) = self.size_and_type();
 
         match type_num {
             1 => {


### PR DESCRIPTION
Moves as much code as possible out of the methods parameterized on Visitor and into non-generic variants, thereby reducing how much code is duplicated due to monomorphization.

The only thing that may impact performance slightly is the addition of the `Value` type since it does introduce an extra branch when checking the enum, but I don't think it affects things much.

Before
```
  Lines          Copies       Function name
  -----          ------       -------------
  140897 (100%)  3010 (100%)  (TOTAL)
   13440 (9.5%)   160 (5.3%)  core::iter::traits::iterator::Iterator::fold
    5310 (3.8%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_any
    4736 (3.4%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_double
    4736 (3.4%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_float
    4318 (3.1%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_int
    4318 (3.1%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_uint128
    4318 (3.1%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_uint16
    4318 (3.1%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_uint32
    4318 (3.1%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_uint64
    4104 (2.9%)    65 (2.2%)  core::result::Result<T,E>::map_err
    3678 (2.6%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_string
    2848 (2.0%)    46 (1.5%)  core::result::Result<T,E>::map
    2750 (2.0%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_bool
    2336 (1.7%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_bytes
    2112 (1.5%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_double::{{closure}}
    2112 (1.5%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_float::{{closure}}
    1760 (1.2%)    32 (1.1%)  <&mut maxminddb::decoder::Decoder as serde::de::Deserializer>::deserialize_any
    1705 (1.2%)     1 (0.0%)  <maxminddb::geoip2::_::<impl serde::de::Deserialize for maxminddb::geoip2::City>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    1632 (1.2%)    32 (1.1%)  maxminddb::decoder::Decoder::decode_map
    1472 (1.0%)    22 (0.7%)  <maxminddb::decoder::MapAccessor as serde::de::MapAccess>::next_value_seed
    1410 (1.0%)     1 (0.0%)  <maxminddb::_::<impl serde::de::Deserialize for maxminddb::Metadata>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    1397 (1.0%)    22 (0.7%)  <maxminddb::decoder::ArrayAccess as serde::de::SeqAccess>::next_element_seed
    1333 (0.9%)    31 (1.0%)  serde::de::Visitor::visit_u128
    1260 (0.9%)    30 (1.0%)  serde::de::Visitor::visit_bool
    1200 (0.9%)    30 (1.0%)  serde::de::Visitor::visit_f64
    1080 (0.8%)    27 (0.9%)  serde::de::Visitor::visit_i64
     876 (0.6%)    41 (1.4%)  <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual

```

After
```
  Lines         Copies       Function name
  -----         ------       -------------
  75428 (100%)  2145 (100%)  (TOTAL)
   7296 (9.7%)    32 (1.5%)  maxminddb::decoder::Decoder::decode_any
   2734 (3.6%)    44 (2.1%)  core::result::Result<T,E>::map
   1760 (2.3%)    32 (1.5%)  <&mut maxminddb::decoder::Decoder as serde::de::Deserializer>::deserialize_any
   1705 (2.3%)     1 (0.0%)  <maxminddb::geoip2::_::<impl serde::de::Deserialize for maxminddb::geoip2::City>::deserialize::__Visitor as serde::de::Visitor>::visit_map
   1472 (2.0%)    22 (1.0%)  <maxminddb::decoder::MapAccessor as serde::de::MapAccess>::next_value_seed
   1410 (1.9%)     1 (0.0%)  <maxminddb::_::<impl serde::de::Deserialize for maxminddb::Metadata>::deserialize::__Visitor as serde::de::Visitor>::visit_map
   1397 (1.9%)    22 (1.0%)  <maxminddb::decoder::ArrayAccess as serde::de::SeqAccess>::next_element_seed
   1333 (1.8%)    31 (1.4%)  serde::de::Visitor::visit_u128
   1260 (1.7%)    30 (1.4%)  serde::de::Visitor::visit_bool
   1200 (1.6%)    30 (1.4%)  serde::de::Visitor::visit_f64
   1080 (1.4%)    27 (1.3%)  serde::de::Visitor::visit_i64
    874 (1.2%)    19 (0.9%)  serde::de::Visitor::visit_bytes
    874 (1.2%)    19 (0.9%)  serde::de::Visitor::visit_str
    872 (1.2%)     1 (0.0%)  <maxminddb::geoip2::_::<impl serde::de::Deserialize for maxminddb::geoip2::City>::deserialize::__Visitor as serde::de::Visitor>::visit_seq
    854 (1.1%)    40 (1.9%)  <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
    803 (1.1%)     1 (0.0%)  <maxminddb::_::<impl serde::de::Deserialize for maxminddb::Metadata>::deserialize::__Visitor as serde::de::Visitor>::visit_seq
    798 (1.1%)    19 (0.9%)  serde::de::Visitor::visit_map
    798 (1.1%)    19 (0.9%)  serde::de::Visitor::visit_seq
    791 (1.0%)    13 (0.6%)  <maxminddb::decoder::MapAccessor as serde::de::MapAccess>::next_key_seed
    770 (1.0%)    14 (0.7%)  <&mut maxminddb::decoder::Decoder a
```