### PR TITLE
Add within support to allow iterating over IpNetworks (cidrs)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ name ="maxminddb"
 path = "src/maxminddb/lib.rs"
 
 [dependencies]
+ipnetwork = "0.18.0"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 memchr = "2.4"

--- a/examples/within.rs
+++ b/examples/within.rs
@@ -19,8 +19,7 @@ fn main() -> Result<(), String> {
     } else {
         IpNetwork::V4(cidr.parse().unwrap())
     };
-    // TODO: error handling
-    for i in reader.within(ip_net).unwrap() {
+    for i in reader.within(ip_net).map_err(|e| e.to_string())? {
         let (ip_net, info): (IpNetwork, geoip2::City) = (i.ip_net, i.info);
         println!("ip_net={}, info={:#?}", ip_net, info);
     }

--- a/examples/within.rs
+++ b/examples/within.rs
@@ -20,7 +20,8 @@ fn main() -> Result<(), String> {
     } else {
         IpNetwork::V4(cidr.parse().unwrap())
     };
-    let within: Within<_, geoip2::City> = reader.within(ip_net).unwrap();
+    // TODO: is there a way to omit the _, it should be discernable from the reader
+    let within: Within<geoip2::City, _> = reader.within(ip_net).unwrap();
     for item in within {
         println!("item={:#?}", item);
     }

--- a/examples/within.rs
+++ b/examples/within.rs
@@ -1,5 +1,5 @@
 use ipnetwork::IpNetwork;
-use maxminddb::{Within, geoip2};
+use maxminddb::{geoip2, Within};
 
 fn main() -> Result<(), String> {
     let mut args = std::env::args().skip(1);

--- a/examples/within.rs
+++ b/examples/within.rs
@@ -1,0 +1,28 @@
+use ipnetwork::IpNetwork;
+
+use maxminddb::geoip2;
+use maxminddb::Within;
+
+fn main() -> Result<(), String> {
+    let mut args = std::env::args().skip(1);
+    let reader = maxminddb::Reader::open_readfile(
+        args.next()
+            .ok_or("First argument must be the path to the IP database")?,
+    )
+    .unwrap();
+    let cidr: String = args
+        .next()
+        .ok_or("Second argument must be the IP address and mask in CIDR notation")?
+        .parse()
+        .unwrap();
+    let ip_net = if cidr.contains(":") {
+        IpNetwork::V6(cidr.parse().unwrap())
+    } else {
+        IpNetwork::V4(cidr.parse().unwrap())
+    };
+    let within: Within<_, geoip2::City> = reader.within(ip_net).unwrap();
+    for item in within {
+        println!("item={:#?}", item);
+    }
+    Ok(())
+}

--- a/examples/within.rs
+++ b/examples/within.rs
@@ -1,7 +1,6 @@
 use ipnetwork::IpNetwork;
 
 use maxminddb::geoip2;
-use maxminddb::Within;
 
 fn main() -> Result<(), String> {
     let mut args = std::env::args().skip(1);
@@ -20,10 +19,10 @@ fn main() -> Result<(), String> {
     } else {
         IpNetwork::V4(cidr.parse().unwrap())
     };
-    // TODO: is there a way to omit the _, it should be discernable from the reader
-    let within: Within<geoip2::City, _> = reader.within(ip_net).unwrap();
-    for item in within {
-        println!("item={:#?}", item);
+    // TODO: error handling
+    for i in reader.within(ip_net).unwrap() {
+        let (ip_net, info): (IpNetwork, geoip2::City) = (i.ip_net, i.info);
+        println!("ip_net={}, info={:#?}", ip_net, info);
     }
     Ok(())
 }

--- a/examples/within.rs
+++ b/examples/within.rs
@@ -19,7 +19,8 @@ fn main() -> Result<(), String> {
     } else {
         IpNetwork::V4(cidr.parse().unwrap())
     };
-    for i in reader.within(ip_net).map_err(|e| e.to_string())? {
+    for r in reader.within(ip_net).map_err(|e| e.to_string())? {
+        let i = r.map_err(|e| e.to_string())?;
         let (ip_net, info): (IpNetwork, geoip2::City) = (i.ip_net, i.info);
         println!("ip_net={}, info={:#?}", ip_net, info);
     }

--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -123,10 +123,10 @@ impl<'de, T: Deserialize<'de>, S: AsRef<[u8]>> Iterator for Within<'de, T, S> {
                     &self.reader.buf.as_ref()[self.reader.pointer_base..],
                     rec,
                 );
-                return Some(Ok(WithinItem {
-                    ip_net,
-                    info: T::deserialize(&mut decoder).unwrap(),
-                }));
+                return match T::deserialize(&mut decoder) {
+                    Ok(info) => Some(Ok(WithinItem { ip_net, info })),
+                    Err(e) => Some(Err(e)),
+                };
             } else if current.node == self.node_count {
                 // Dead end, nothing to do
             } else {

--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -1,3 +1,5 @@
+#![deny(trivial_casts, trivial_numeric_casts, unused_import_braces)]
+
 use std::collections::BTreeMap;
 use std::fmt::{self, Display, Formatter};
 use std::io;
@@ -153,6 +155,7 @@ impl<'de, T: Deserialize<'de>, S: AsRef<[u8]>> Iterator for Within<'de, T, S> {
                         Err(e) => return Some(Err(e)),
                     };
                 //println!("      emit: current={:#?}, net={}", current, net);
+                // TODO: should this block become a helper method on reader?
                 let rec = match self.reader.resolve_data_pointer(current.node) {
                     Ok(rec) => rec,
                     Err(e) => return Some(Err(e)),

--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -271,11 +271,13 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
     /// use ipnetwork::IpNetwork;
     /// use maxminddb::{geoip2, Within};
     ///
-    /// let ip_net = IpNetwork::V6("::/0");
-    /// let mut iter: Within<geoip2::City, _> = reader.within(ip_net).map_err(|e| e.to_string())?;
+    /// let reader = maxminddb::Reader::open_readfile("test-data/test-data/GeoIP2-City-Test.mmdb").unwrap();
+    ///
+    /// let ip_net = IpNetwork::V6("::/0".parse().unwrap());
+    /// let mut iter: Within<geoip2::City, _> = reader.within(ip_net).unwrap();
     /// while let Some(next) = iter.next() {
-    ///     let item = next.map_err(|e| e.to_string())?;
-    ///     println!("ip_net={}, city={:?}", item.ip_net, city)
+    ///     let item = next.unwrap();
+    ///     println!("ip_net={}, city={:?}", item.ip_net, item.info);
     /// }
     /// ```
     pub fn within<T>(&'de self, cidr: IpNetwork) -> Result<Within<T, S>, MaxMindDBError>

--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -120,7 +120,7 @@ struct WithinNode {
 }
 
 #[derive(Debug)]
-pub struct Within<'de, S: AsRef<[u8]>, T: Deserialize<'de>> {
+pub struct Within<'de, T: Deserialize<'de>, S: AsRef<[u8]>> {
     reader: &'de Reader<S>,
     stack: Vec<WithinNode>,
     // TODO: how do i prevent unused T warnings
@@ -133,7 +133,7 @@ pub struct WithinItem<T> {
     pub info: T
 }
 
-impl<'de, S: AsRef<[u8]>, T: Deserialize<'de>> Iterator for Within<'de, S, T> {
+impl<'de, T: Deserialize<'de>, S: AsRef<[u8]>> Iterator for Within<'de, T, S> {
     type Item = WithinItem<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -244,7 +244,7 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
         T::deserialize(&mut decoder)
     }
 
-    pub fn within<T>(&'de self, cidr: IpNetwork) -> Result<Within<S, T>, MaxMindDBError>
+    pub fn within<T>(&'de self, cidr: IpNetwork) -> Result<Within<T, S>, MaxMindDBError>
     where
         T: Deserialize<'de>,
     {
@@ -291,7 +291,7 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
         // which makes sense.
 
 //        println!("  stack={:#?}", stack);
-        let within: Within<S, T> = Within {
+        let within: Within<T, S> = Within {
             reader: self,
             stack,
             _out: None,

--- a/src/maxminddb/reader_test.rs
+++ b/src/maxminddb/reader_test.rs
@@ -386,6 +386,26 @@ fn test_within_city() {
     }
 }
 
+#[test]
+fn test_within_broken_database() {
+    use super::geoip2::City;
+    use ipnetwork::IpNetwork;
+
+    let r = Reader::open_readfile("test-data/test-data/GeoIP2-City-Test-Broken-Double-Format.mmdb")
+        .ok()
+        .unwrap();
+
+    let ip_net = IpNetwork::V6("::/0".parse().unwrap());
+    let mut iter = r.within::<City>(ip_net).unwrap();
+    match iter.next().unwrap() {
+        Err(e) => assert_eq!(
+            e,
+            MaxMindDBError::InvalidDatabaseError("double of size 7".to_string())
+        ),
+        Ok(_) => panic!("Error expected"),
+    };
+}
+
 fn check_metadata<T: AsRef<[u8]>>(reader: &Reader<T>, ip_version: usize, record_size: usize) {
     let metadata = &reader.metadata;
 


### PR DESCRIPTION
This is akin to golang's `within` support, mostly implemented in https://github.com/oschwald/maxminddb-golang/blob/main/traverse.go, but the implementation itself is done from scratch to better match the style and details of this rust implementation. 

It's still a work in progress, mostly kicking the tires and iterating towards a working/clean solution. The status is roughly:

* [x] Implement the algorithm to search for the starting node
* [x] Stack based in-order traversal (which will be well suited to convert to an iterator)
* [x] Implement the iterator with an item that that includes both the network and info
* [x] Make a quick example in the spirit of lookup.rs
* [x] Make sure this is on the right track and is something that would be shippable
* [x] Figure out if there's a cleaner way to get the Reader's type parameter into Within to avoid having to `_` it. 
* [x] Error handling
* [x] Organize/layout the code better
* [x] Write tests & search for edge cases
   * [x] Especially the IPv6 bits
* [x] Cleanup/remove prints and other debugging bits
* ...

