### PR TITLE
Re-export `Mmap`

### DIFF
--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use serde::{de, Deserialize};
 
 #[cfg(feature = "mmap")]
-use memmap2::Mmap;
+pub use memmap2::Mmap;
 #[cfg(feature = "mmap")]
 use memmap2::MmapOptions;
 #[cfg(feature = "mmap")]


### PR DESCRIPTION
Currently, the `Mmap` is not exported thus if a user needs to use `Reader<Mmap>` the user would need to add dependency to `mmap` explicitly. 

And that causes the issue with `mmap` version. The latest `mmap` is `0.5.1` and current `maxminddb-rust` requires `0.3.2`. The user would have to fix the version of `mmap` to `0.3.2` and make sure never to update it to the latest.