### PR TITLE
Don't run CI on dependabot branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 name: Rust
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Currenly CI is run twice for each update posted by dependabot. Once on the PR and once on the branch.