### PR TITLE
Add a github-actions section to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "weekly"


### PR DESCRIPTION
With this dependabot will also watch the workflows in `.github/workflows` for
possible updates to the actions in use.

Fixed the indentation of the existing cargo section while at it.