### PR TITLE
Add missing `is_anycast` trait

### DIFF
--- a/src/maxminddb/geoip2.rs
+++ b/src/maxminddb/geoip2.rs
@@ -122,6 +122,7 @@ pub mod country {
     #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct Traits {
         pub is_anonymous_proxy: Option<bool>,
+        pub is_anycast: Option<bool>,
         pub is_satellite_provider: Option<bool>,
     }
 }
@@ -218,6 +219,7 @@ pub mod enterprise {
         pub is_anonymous: Option<bool>,
         pub is_anonymous_proxy: Option<bool>,
         pub is_anonymous_vpn: Option<bool>,
+        pub is_anycast: Option<bool>,
         pub is_hosting_provider: Option<bool>,
         pub isp: Option<&'a str>,
         pub is_public_proxy: Option<bool>,


### PR DESCRIPTION
In December, maxmind added a new `is_anycast` flag to their database files ([Changelog](https://dev.maxmind.com/geoip/release-notes/2023#anycast-flag-available-for-geoip-web-services-and-databases)).

This PR adds that to the default `Traits` structs which are exported by this library.

I've tested these changes locally, and confirmed that they are correct.