### PR TITLE
Add `Serialize` and `Clone` to `Metadata` struct

### DIFF
--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -9,7 +9,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::Path;
 
 use ipnetwork::IpNetwork;
-use serde::{de, Deserialize};
+use serde::{de, Deserialize, Serialize};
 
 #[cfg(feature = "mmap")]
 pub use memmap2::Mmap;
@@ -62,7 +62,7 @@ impl de::Error for MaxMindDBError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Metadata {
     pub binary_format_major_version: u16,
     pub binary_format_minor_version: u16,


### PR DESCRIPTION
I'm currently using this workaround: https://serde.rs/remote-derive.html

```rust
#[derive(Serialize, Clone)]
#[serde(remote = "Metadata")]
struct MetadataDef {
  binary_format_major_version: u16,
  binary_format_minor_version: u16,
  build_epoch: u64,
  database_type: String,
  description: BTreeMap<String, String>,
  ip_version: u16,
  languages: Vec<String>,
  node_count: u32,
  record_size: u16,
}

#[derive(Serialize, Clone)]
struct MetadataWrapper<'a>(#[serde(with = "MetadataDef")] &'a Metadata);



// ...

let json_string = json!(&MetadataWrapper(&reader.metadata)).to_string();
```
