### PR TITLE
Add new feature: simdutf8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 
 [features]
 default = []
+simdutf8 = ["dep:simdutf8"]
 mmap = ["memmap2"]
 unsafe-str-decode = []
 
@@ -28,6 +29,7 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 memchr = "2.4"
 memmap2 = { version = "0.9.0", optional = true }
+simdutf8 = { version = "0.1.5", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/src/maxminddb/decoder.rs
+++ b/src/maxminddb/decoder.rs
@@ -328,6 +328,9 @@ impl<'de> Decoder<'de> {
 
     #[cfg(not(feature = "unsafe-str-decode"))]
     fn decode_string(&mut self, size: usize) -> DecodeResult<&'de str> {
+        #[cfg(feature = "simdutf8")]
+        use simdutf8::basic::from_utf8;
+        #[cfg(not(feature = "simdutf8"))]
         use std::str::from_utf8;
 
         let new_offset: usize = self.current_ptr + size;

--- a/src/maxminddb/lib.rs
+++ b/src/maxminddb/lib.rs
@@ -18,6 +18,9 @@ use memmap2::MmapOptions;
 #[cfg(feature = "mmap")]
 use std::fs::File;
 
+#[cfg(all(feature = "simdutf8", feature = "unsafe-str-decode"))]
+compile_error!("features `simdutf8` and `unsafe-str-decode` are mutually exclusive");
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum MaxMindDBError {
     AddressNotFoundError(String),


### PR DESCRIPTION
[Using simdutf8 is usually 4-11 times faster than Rust stdlib implementation.](https://github.com/rusticstuff/simdutf8) This is alternative when unsafe-str-decode is too risky to use.