### PR TITLE
ADHOC: Support the Network trait from GeoIP2 responses

### DIFF
--- a/src/maxminddb/geoip2.rs
+++ b/src/maxminddb/geoip2.rs
@@ -334,5 +334,7 @@ pub mod enterprise {
         pub organization: Option<&'a str>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub user_type: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub network: Option<&'a str>,
     }
 }

--- a/src/maxminddb/geoip2.rs
+++ b/src/maxminddb/geoip2.rs
@@ -79,6 +79,8 @@ pub struct Isp<'a> {
     pub mobile_network_code: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub organization: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<&'a str>,
 }
 
 /// GeoIP2 Connection-Type record


### PR DESCRIPTION
### Problem

Missing field that's present in other implementations in other languages for the enterprise model

### Solution

Deserialize it and add it to the response model

### Testing

```
cargo build && cargo bench
```

```

test result: ok. 0 passed; 0 failed; 21 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/lookup.rs (target/release/deps/lookup-8d8170d3ccb9b01f)
Gnuplot not found, using plotters backend
maxminddb               time:   [24.882 µs 25.450 µs 26.201 µs]
                        change: [-1.6018% +0.8070% +3.9136%] (p = 0.70 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

maxminddb_par           time:   [38.782 µs 39.229 µs 40.051 µs]
                        change: [-2.8518% +1.7507% +6.6279%] (p = 0.50 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```