### PR TITLE
Revert "Set release log level to info at compile time"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ name = "maxminddb"
 
 [dependencies]
 ipnetwork = "0.21.1"
-log = { version = "0.4", features = ["release_max_level_info"] }
+log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 memchr = "2.4"
 memmap2 = { version = "0.9.0", optional = true }


### PR DESCRIPTION
Fixes #109 

This reverts commit e525987b98712e731420d149a6a8347381535745.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging dependency configuration to use default feature settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->