### PR TITLE
Harden reader validation without slowing hot paths

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,7 +19,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build documentation with warnings denied
-        run: cargo doc --all --no-deps
+        run: cargo doc --all --features mmap,simdutf8 --no-deps
         env:
           RUSTDOCFLAGS: -D warnings
 
@@ -37,7 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Documentation
-        run: cargo doc --all --no-deps
+        run: cargo doc --all --features mmap,simdutf8 --no-deps
         env:
           RUSTDOCFLAGS: -D warnings
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Run cargo check
-        run: cargo check
+        run: cargo check --features mmap,simdutf8
 
   test:
     name: Test Suite
@@ -50,6 +50,36 @@ jobs:
       - name: Run cargo test
         run: cargo test
 
+  feature-test:
+    name: Feature Tests
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            features: mmap
+          - platform: ubuntu-latest
+            features: mmap,simdutf8
+          - platform: ubuntu-latest
+            features: unsafe-str-decode
+          - platform: ubuntu-latest
+            features: mmap,unsafe-str-decode
+          - platform: macos-latest
+            features: mmap
+          - platform: windows-latest
+            features: mmap
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run feature tests
+        run: cargo test --features "${{ matrix.features }}"
+
   lints:
     name: Lints
     runs-on: ubuntu-latest
@@ -66,4 +96,4 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --features mmap,simdutf8 -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed network iteration on cyclic or over-deep corrupt search trees so it
+  returns an error instead of looping indefinitely.
 - Fixed `verify()` to validate shared data-section pointer targets once, reject
   pointer cycles, invalid scalar encodings, and impossible container sizes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Fixed `verify()` to validate shared data-section pointer targets once, reject
+  pointer cycles, invalid scalar encodings, and impossible container sizes.
+
 ## 0.29.0 - 2026-06-28
 
 - Breaking: `Metadata::build_time()` now returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed network iteration on cyclic or over-deep corrupt search trees so it
   returns an error instead of looping indefinitely.
+- Fixed `decode_path()` error rendering for extreme negative indexes and
+  reduced path traversal header parsing.
 - Fixed `verify()` to validate shared data-section pointer targets once, reject
   pointer cycles, invalid scalar encodings, and impossible container sizes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   returns an error instead of looping indefinitely.
 - Fixed `decode_path()` error rendering for extreme negative indexes and
   reduced path traversal header parsing.
+- Removed decoder logging checks from hot deserialization paths.
 - Fixed `verify()` to validate shared data-section pointer targets once, reject
   pointer cycles, invalid scalar encodings, and impossible container sizes.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ name = "maxminddb"
 
 [dependencies]
 ipnetwork = "0.21.1"
-log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 memchr = "2.4"
 memmap2 = { version = "0.9.0", optional = true }

--- a/benches/metadata.rs
+++ b/benches/metadata.rs
@@ -5,8 +5,14 @@ use criterion::{criterion_group, criterion_main, Criterion};
 const DB_FILE: &str = "GeoLite2-City.mmdb";
 
 pub fn metadata_benchmark(c: &mut Criterion) {
+    let database = std::fs::read(DB_FILE).unwrap();
     let reader = maxminddb::Reader::open_readfile(DB_FILE).unwrap();
 
+    c.bench_function("reader/from_source", |b| {
+        b.iter(|| {
+            black_box(maxminddb::Reader::from_source(black_box(database.as_slice())).unwrap())
+        })
+    });
     c.bench_function("metadata/build_time", |b| {
         b.iter(|| black_box(reader.metadata().build_time().unwrap()))
     });

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -7,7 +7,6 @@
 //! Most users should not need to interact with this module directly.
 //! Use [`Reader::lookup()`](crate::Reader::lookup) for normal lookups.
 
-use log::debug;
 use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use serde::forward_to_deserialize_any;
 use std::collections::HashSet;
@@ -913,8 +912,6 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
     where
         V: Visitor<'de>,
     {
-        debug!("deserialize_any");
-
         self.decode_any(visitor)
     }
 
@@ -922,8 +919,6 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
     where
         V: Visitor<'de>,
     {
-        debug!("deserialize_option");
-
         visitor.visit_some(self)
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -535,35 +535,9 @@ impl<'de> Decoder<'de> {
         Ok(result)
     }
 
-    /// Consumes a map header, returning its size. Follows pointers.
-    pub(crate) fn consume_map_header(&mut self) -> DecodeResult<usize> {
-        self.consume_typed_header(TYPE_MAP, "map")
-    }
-
-    /// Consumes an array header, returning its size. Follows pointers.
-    pub(crate) fn consume_array_header(&mut self) -> DecodeResult<usize> {
-        self.consume_typed_header(TYPE_ARRAY, "array")
-    }
-
-    /// Consumes a header of the expected type, following one pointer.
-    fn consume_typed_header(&mut self, expected_type: u8, label: &str) -> DecodeResult<usize> {
-        let (size, type_num) = self.size_and_type()?;
-        if type_num == TYPE_POINTER {
-            self.current_ptr = self.decode_pointer(size);
-            let (size, type_num) = self.size_and_type()?;
-            if type_num == TYPE_POINTER {
-                return Err(self.invalid_db_error("pointer points to another pointer"));
-            }
-            if type_num == expected_type {
-                return Ok(size);
-            }
-            return Err(self.decode_error(&format!("expected {label}, got type {type_num}")));
-        }
-        if type_num == expected_type {
-            Ok(size)
-        } else {
-            Err(self.decode_error(&format!("expected {label}, got type {type_num}")))
-        }
+    /// Consumes a map or array header in one pass, following a pointer if needed.
+    pub(crate) fn consume_container_header(&mut self) -> DecodeResult<(usize, u8)> {
+        self.size_and_type_following_pointers()
     }
 
     /// Gets size and type, following any pointers.

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -10,6 +10,7 @@
 use log::debug;
 use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use serde::forward_to_deserialize_any;
+use std::collections::HashSet;
 use std::convert::TryInto;
 
 use crate::error::MaxMindDbError;
@@ -113,6 +114,13 @@ pub(crate) struct Decoder<'de> {
     depth: u16,
 }
 
+/// Tracks data values visited by a single database verification pass.
+#[derive(Debug, Default)]
+pub(crate) struct VerificationState {
+    validated: HashSet<usize>,
+    active: HashSet<usize>,
+}
+
 impl<'de> Decoder<'de> {
     pub(crate) fn new(buf: &'de [u8], start_ptr: usize) -> Decoder<'de> {
         Decoder::new_with_limit(buf, start_ptr, buf.len())
@@ -189,7 +197,8 @@ impl<'de> Decoder<'de> {
 
     #[inline(always)]
     fn skip_bytes(&mut self, size: usize, label: &str) -> DecodeResult<()> {
-        if self.current_ptr > self.limit || size > self.limit - self.current_ptr {
+        debug_assert!(self.current_ptr <= self.limit);
+        if size > self.limit - self.current_ptr {
             return Err(self.invalid_db_error(&format!("{label} of size {size}")));
         }
         self.current_ptr += size;
@@ -692,14 +701,35 @@ impl<'de> Decoder<'de> {
     /// Skips the current value, following pointers.
     pub(crate) fn skip_value(&mut self) -> DecodeResult<()> {
         let (size, type_num) = self.size_and_type()?;
-        self.skip_value_inner(size, type_num, true, 0)
+        self.skip_value_inner(size, type_num, 0)
     }
 
-    /// Skips the current value without following pointers (for verification).
-    pub(crate) fn skip_value_for_verification(&mut self) -> DecodeResult<()> {
-        let (size, type_num) = self.size_and_type()?;
-        self.skip_value_inner(size, type_num, false, 0)?;
-        self.validate_skip_end()
+    /// Skips the current value and validates any referenced pointer targets.
+    pub(crate) fn skip_value_for_verification(
+        &mut self,
+        state: &mut VerificationState,
+    ) -> DecodeResult<()> {
+        let offset = self.current_ptr;
+        if state.validated.contains(&offset) {
+            return Ok(());
+        }
+        if !state.active.insert(offset) {
+            return Err(
+                self.invalid_db_error(&format!("cyclic data pointer references offset {offset}"))
+            );
+        }
+
+        let result = (|| {
+            let (size, type_num) = self.size_and_type()?;
+            self.skip_value_inner_for_verification(size, type_num, 0, state)?;
+            self.validate_skip_end()
+        })();
+
+        state.active.remove(&offset);
+        if result.is_ok() {
+            state.validated.insert(offset);
+        }
+        result
     }
 
     #[inline(always)]
@@ -725,34 +755,21 @@ impl<'de> Decoder<'de> {
     }
 
     #[inline(always)]
-    fn skip_value_inner(
-        &mut self,
-        size: usize,
-        type_num: u8,
-        follow_pointers: bool,
-        skip_depth: u16,
-    ) -> DecodeResult<()> {
-        // When following pointers during normal serde skips, scalar payload
-        // bounds are validated once the whole skipped value is consumed. The
-        // no-follow verification path validates each raw payload immediately.
+    fn skip_value_inner(&mut self, size: usize, type_num: u8, skip_depth: u16) -> DecodeResult<()> {
+        // Headers and scalar payloads validate every cursor advance. A
+        // successful recursive skip therefore already guarantees that the
+        // cursor remains within the decoder limit.
         match type_num {
             TYPE_POINTER => {
-                if follow_pointers {
-                    let new_ptr = self.decode_pointer(size);
-                    let saved_ptr = self.current_ptr;
-                    self.current_ptr = new_ptr;
-                    let result = match self.check_skip_depth(skip_depth) {
-                        Ok(child_depth) => match self.skip_value_with_depth(child_depth) {
-                            Ok(()) => self.validate_skip_end(),
-                            Err(err) => Err(err),
-                        },
-                        Err(err) => Err(err),
-                    };
-                    self.current_ptr = saved_ptr;
-                    return result;
-                }
-                let pointer_size = ((size >> 3) & 0x3) + 1;
-                self.skip_bytes(pointer_size, "pointer")
+                let new_ptr = self.decode_pointer(size);
+                let saved_ptr = self.current_ptr;
+                self.current_ptr = new_ptr;
+                let result = match self.check_skip_depth(skip_depth) {
+                    Ok(child_depth) => self.skip_value_with_depth(child_depth),
+                    Err(err) => Err(err),
+                };
+                self.current_ptr = saved_ptr;
+                result
             }
             TYPE_STRING | TYPE_BYTES => {
                 // String or Bytes - skip size bytes
@@ -761,36 +778,21 @@ impl<'de> Decoder<'de> {
                 } else {
                     "bytes"
                 };
-                if follow_pointers {
-                    self.current_ptr += size;
-                    Ok(())
-                } else {
-                    self.skip_bytes(size, label)
-                }
+                self.skip_bytes(size, label)
             }
             TYPE_DOUBLE => {
                 // Double - must be exactly 8 bytes
                 if size != 8 {
                     return Err(self.invalid_db_error(&format!("double of size {size}")));
                 }
-                if follow_pointers {
-                    self.current_ptr += size;
-                    Ok(())
-                } else {
-                    self.skip_bytes(size, "double")
-                }
+                self.skip_bytes(size, "double")
             }
             TYPE_FLOAT => {
                 // Float - must be exactly 4 bytes
                 if size != 4 {
                     return Err(self.invalid_db_error(&format!("float of size {size}")));
                 }
-                if follow_pointers {
-                    self.current_ptr += size;
-                    Ok(())
-                } else {
-                    self.skip_bytes(size, "float")
-                }
+                self.skip_bytes(size, "float")
             }
             TYPE_UINT16 | TYPE_UINT32 | TYPE_INT32 | TYPE_UINT64 | TYPE_UINT128 => {
                 // Numeric types - skip size bytes
@@ -802,25 +804,30 @@ impl<'de> Decoder<'de> {
                     TYPE_UINT128 => "u128",
                     _ => unreachable!(),
                 };
-                if follow_pointers {
-                    self.current_ptr += size;
-                    Ok(())
-                } else {
-                    self.skip_bytes(size, label)
+                let max_size = match type_num {
+                    TYPE_UINT16 => 2,
+                    TYPE_UINT32 | TYPE_INT32 => 4,
+                    TYPE_UINT64 => 8,
+                    TYPE_UINT128 => 16,
+                    _ => unreachable!(),
+                };
+                if size > max_size {
+                    return Err(self.invalid_db_error(&format!("{label} of size {size}")));
                 }
+                self.skip_bytes(size, label)
             }
             TYPE_BOOL => {
                 // Boolean - size field IS the value, no data bytes to skip
-                Ok(())
+                self.decode_bool(size).map(|_| ())
             }
             TYPE_MAP => {
                 // Map - skip size key-value pairs
                 let child_depth = self.check_skip_depth(skip_depth)?;
                 for _ in 0..size {
                     // key
-                    self.skip_value_inner_with_follow(follow_pointers, child_depth)?;
+                    self.skip_value_with_depth(child_depth)?;
                     // value
-                    self.skip_value_inner_with_follow(follow_pointers, child_depth)?;
+                    self.skip_value_with_depth(child_depth)?;
                 }
                 Ok(())
             }
@@ -828,7 +835,7 @@ impl<'de> Decoder<'de> {
                 // Array - skip size elements
                 let child_depth = self.check_skip_depth(skip_depth)?;
                 for _ in 0..size {
-                    self.skip_value_inner_with_follow(follow_pointers, child_depth)?;
+                    self.skip_value_with_depth(child_depth)?;
                 }
                 Ok(())
             }
@@ -839,17 +846,87 @@ impl<'de> Decoder<'de> {
     #[inline(always)]
     fn skip_value_with_depth(&mut self, skip_depth: u16) -> DecodeResult<()> {
         let (size, type_num) = self.size_and_type()?;
-        self.skip_value_inner(size, type_num, true, skip_depth)
+        self.skip_value_inner(size, type_num, skip_depth)
     }
 
-    #[inline(always)]
-    fn skip_value_inner_with_follow(
+    fn skip_value_inner_for_verification(
         &mut self,
-        follow_pointers: bool,
+        size: usize,
+        type_num: u8,
         skip_depth: u16,
+        state: &mut VerificationState,
+    ) -> DecodeResult<()> {
+        match type_num {
+            TYPE_STRING => {
+                let end = self.checked_offset(size, "string")?;
+                let bytes = self.slice(self.current_ptr, end);
+                self.current_ptr = end;
+                std::str::from_utf8(bytes)
+                    .map(|_| ())
+                    .map_err(|_| self.invalid_db_error("invalid UTF-8 in string"))
+            }
+            TYPE_POINTER => {
+                let target = self.decode_pointer(size);
+                let child_depth = self.check_skip_depth(skip_depth)?;
+                self.verify_pointer_target(target, child_depth, state)
+            }
+            TYPE_MAP => {
+                let child_depth = self.check_skip_depth(skip_depth)?;
+                for _ in 0..size {
+                    self.skip_value_with_verification(child_depth, state)?;
+                    self.skip_value_with_verification(child_depth, state)?;
+                }
+                self.validate_skip_end()
+            }
+            TYPE_ARRAY => {
+                let child_depth = self.check_skip_depth(skip_depth)?;
+                for _ in 0..size {
+                    self.skip_value_with_verification(child_depth, state)?;
+                }
+                self.validate_skip_end()
+            }
+            _ => self.skip_value_inner(size, type_num, skip_depth),
+        }
+    }
+
+    fn skip_value_with_verification(
+        &mut self,
+        skip_depth: u16,
+        state: &mut VerificationState,
     ) -> DecodeResult<()> {
         let (size, type_num) = self.size_and_type()?;
-        self.skip_value_inner(size, type_num, follow_pointers, skip_depth)
+        self.skip_value_inner_for_verification(size, type_num, skip_depth, state)
+    }
+
+    fn verify_pointer_target(
+        &mut self,
+        target: usize,
+        skip_depth: u16,
+        state: &mut VerificationState,
+    ) -> DecodeResult<()> {
+        if state.validated.contains(&target) {
+            return Ok(());
+        }
+        if !state.active.insert(target) {
+            return Err(
+                self.invalid_db_error(&format!("cyclic data pointer references offset {target}"))
+            );
+        }
+
+        let continuation = self.current_ptr;
+        self.current_ptr = target;
+        let result = (|| {
+            let (size, type_num) = self.size_and_type()?;
+            self.skip_value_inner_for_verification(size, type_num, skip_depth, state)?;
+            self.validate_skip_end()
+        })();
+        self.current_ptr = continuation;
+
+        state.active.remove(&target);
+        if result.is_ok() {
+            state.validated.insert(target);
+        }
+        result
     }
 }
 
@@ -1027,9 +1104,6 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
         V: Visitor<'de>,
     {
         self.skip_value()?;
-        if self.depth == 0 {
-            self.validate_skip_end()?;
-        }
         visitor.visit_unit()
     }
 
@@ -1070,8 +1144,13 @@ struct ArrayAccess<'a, 'de: 'a> {
 impl<'de> SeqAccess<'de> for ArrayAccess<'_, 'de> {
     type Error = MaxMindDbError;
 
+    #[inline(always)]
     fn size_hint(&self) -> Option<usize> {
-        Some(self.count)
+        // Never let a corrupt declared count drive an allocation larger than
+        // the remaining encoded data can possibly fill.
+        // Cursor advances are checked, so ordinary subtraction is sufficient.
+        debug_assert!(self.de.current_ptr <= self.de.limit);
+        Some(self.count.min(self.de.limit - self.de.current_ptr))
     }
 
     fn next_element_seed<T>(&mut self, seed: T) -> DecodeResult<Option<T::Value>>
@@ -1080,9 +1159,7 @@ impl<'de> SeqAccess<'de> for ArrayAccess<'_, 'de> {
     {
         // Check if there are no more elements.
         if self.count == 0 {
-            // Only top-level containers need an explicit final overrun check.
-            // Nested containers are bounded by the value that contains them.
-            if self.de.depth <= 1 && self.de.current_ptr > self.de.limit {
+            if self.de.current_ptr > self.de.limit {
                 return Err(self
                     .de
                     .invalid_db_error("skipped value extends beyond buffer"));
@@ -1106,8 +1183,12 @@ struct MapAccessor<'a, 'de: 'a> {
 impl<'de> MapAccess<'de> for MapAccessor<'_, 'de> {
     type Error = MaxMindDbError;
 
+    #[inline(always)]
     fn size_hint(&self) -> Option<usize> {
-        Some(self.count / 2)
+        // Each map entry needs at least one control byte for both key and value.
+        // Cursor advances are checked, so ordinary subtraction is sufficient.
+        debug_assert!(self.de.current_ptr <= self.de.limit);
+        Some((self.count / 2).min((self.de.limit - self.de.current_ptr) / 2))
     }
 
     fn next_key_seed<K>(&mut self, seed: K) -> DecodeResult<Option<K::Value>>
@@ -1116,9 +1197,7 @@ impl<'de> MapAccess<'de> for MapAccessor<'_, 'de> {
     {
         // Check if there are no more entries.
         if self.count == 0 {
-            // Only top-level containers need an explicit final overrun check.
-            // Nested containers are bounded by the value that contains them.
-            if self.de.depth <= 1 && self.de.current_ptr > self.de.limit {
+            if self.de.current_ptr > self.de.limit {
                 return Err(self
                     .de
                     .invalid_db_error("skipped value extends beyond buffer"));
@@ -1199,9 +1278,11 @@ impl<'de> de::VariantAccess<'de> for EnumAccessor<'_, 'de> {
 
 #[cfg(test)]
 mod tests {
+    use serde::Deserialize;
+
     use crate::{MaxMindDbError, Reader};
 
-    use super::Decoder;
+    use super::{Decoder, VerificationState};
 
     #[test]
     fn test_decoder_accepts_tuple_with_matching_length() {
@@ -1270,8 +1351,102 @@ mod tests {
     #[test]
     fn test_skip_value_for_verification_rejects_truncated_pointer_payload() {
         let mut decoder = Decoder::new(&[0x28], 0);
-        let err = decoder.skip_value_for_verification().unwrap_err();
+        let err = decoder
+            .skip_value_for_verification(&mut VerificationState::default())
+            .unwrap_err();
 
         assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+    }
+
+    #[test]
+    fn test_decoder_caps_impossible_container_size_hint() {
+        // Extended array with 284 declared elements and no element payload.
+        let mut decoder = Decoder::new(&[0x1d, 0x04, 0xff], 0);
+        let err = Vec::<serde::de::IgnoredAny>::deserialize(&mut decoder).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(err.to_string().contains("unexpected end of buffer"));
+    }
+
+    #[test]
+    fn test_verification_rejects_invalid_bool_size() {
+        // Extended bool type with an invalid size value of two.
+        let mut decoder = Decoder::new(&[0x02, 0x07], 0);
+        let err = decoder
+            .skip_value_for_verification(&mut VerificationState::default())
+            .unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+    }
+
+    #[test]
+    fn test_verification_rejects_and_does_not_cache_invalid_utf8() {
+        let buf = [0x41, 0xff];
+        let mut state = VerificationState::default();
+
+        for _ in 0..2 {
+            let mut decoder = Decoder::new(&buf, 0);
+            let err = decoder.skip_value_for_verification(&mut state).unwrap_err();
+
+            assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+            assert!(err.to_string().contains("invalid UTF-8"));
+            assert!(state.validated.is_empty());
+            assert!(state.active.is_empty());
+        }
+
+        #[cfg(not(feature = "unsafe-str-decode"))]
+        {
+            let mut decoder = Decoder::new(&buf, 0);
+            let err = String::deserialize(&mut decoder).unwrap_err();
+            assert!(err.to_string().contains("invalid UTF-8"));
+        }
+    }
+
+    fn append_pointer(buf: &mut Vec<u8>, target: usize) {
+        assert!(target < 2048);
+        buf.push(0x20 | ((target >> 8) as u8));
+        buf.push(target as u8);
+    }
+
+    #[test]
+    fn test_verification_caches_shared_pointer_targets() {
+        // A false boolean leaf followed by arrays containing two pointers to
+        // the preceding value. Without caching, verification work doubles at
+        // every level even though the encoded graph grows only linearly.
+        let mut buf = vec![0x00, 0x07];
+        let mut target = 0;
+        const LEVELS: usize = 20;
+
+        for _ in 0..LEVELS {
+            let array = buf.len();
+            buf.extend_from_slice(&[0x02, 0x04]);
+            append_pointer(&mut buf, target);
+            append_pointer(&mut buf, target);
+            target = array;
+        }
+
+        let mut decoder = Decoder::new(&buf, target);
+        let mut state = VerificationState::default();
+        decoder.skip_value_for_verification(&mut state).unwrap();
+
+        assert_eq!(state.validated.len(), LEVELS + 1);
+        assert!(state.active.is_empty());
+    }
+
+    #[test]
+    fn test_verification_rejects_data_pointer_cycles() {
+        // Two single-element arrays whose values point to each other.
+        let mut buf = vec![0x01, 0x04];
+        append_pointer(&mut buf, 4);
+        buf.extend_from_slice(&[0x01, 0x04]);
+        append_pointer(&mut buf, 0);
+
+        let mut decoder = Decoder::new(&buf, 0);
+        let err = decoder
+            .skip_value_for_verification(&mut VerificationState::default())
+            .unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(err.to_string().contains("cyclic data pointer"));
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -625,7 +625,9 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
     /// - Debugging database corruption issues
     /// - Ensuring database integrity in critical applications
     ///
-    /// Note: Verification traverses the entire database and may be slow on large files.
+    /// Note: Verification traverses the entire database and retains visited data
+    /// offsets for the duration of the call. It may be slow and use memory
+    /// proportional to the number of distinct referenced values on large files.
     /// The method is thread-safe and can be called on an active Reader.
     ///
     /// # Example
@@ -723,6 +725,7 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
         data_section_end: usize,
     ) -> Result<(), MaxMindDbError> {
         let data_section = &self.buf.as_ref()[self.pointer_base..data_section_end];
+        let mut verification_state = decoder::VerificationState::default();
 
         // Verify each offset from the search tree points to valid, decodable data
         for &offset in &offsets {
@@ -739,7 +742,7 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
             let mut dec = decoder::Decoder::new(data_section, offset);
 
             // Try to skip/decode the value to verify it's valid
-            if let Err(e) = dec.skip_value_for_verification() {
+            if let Err(e) = dec.skip_value_for_verification(&mut verification_state) {
                 return Err(MaxMindDbError::invalid_database_at(
                     format!("decoding error: {e}"),
                     offset,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -542,16 +542,13 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
         // We are looking up an IPv4 address in an IPv6 tree. Skip over the
         // first 96 nodes.
         let mut node: usize = 0;
-        let mut depth: usize = 0;
         for i in 0_u8..96 {
             if node >= self.node_count {
-                depth = i as usize;
-                break;
+                return (node, i as usize);
             }
             node = self.read_node(node, 0);
-            depth = (i + 1) as usize;
         }
-        (node, depth)
+        (node, 96)
     }
 
     #[inline(always)]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -554,34 +554,11 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
     #[inline(always)]
     pub(crate) fn read_node(&self, node_number: usize, index: usize) -> usize {
         let buf = self.buf.as_ref();
-        let base_offset = node_number * self.node_byte_size;
 
         match self.record_size {
-            24 => {
-                let offset = base_offset + index * 3;
-                (buf[offset] as usize) << 16
-                    | (buf[offset + 1] as usize) << 8
-                    | buf[offset + 2] as usize
-            }
-            28 => {
-                let middle = if index != 0 {
-                    buf[base_offset + 3] & 0x0F
-                } else {
-                    (buf[base_offset + 3] & 0xF0) >> 4
-                };
-                let offset = base_offset + index * 4;
-                (middle as usize) << 24
-                    | (buf[offset] as usize) << 16
-                    | (buf[offset + 1] as usize) << 8
-                    | buf[offset + 2] as usize
-            }
-            32 => {
-                let offset = base_offset + index * 4;
-                (buf[offset] as usize) << 24
-                    | (buf[offset + 1] as usize) << 16
-                    | (buf[offset + 2] as usize) << 8
-                    | buf[offset + 3] as usize
-            }
+            24 => RecordSize24::read_node(buf, node_number, index),
+            28 => RecordSize28::read_node(buf, node_number, index),
+            32 => RecordSize32::read_node(buf, node_number, index),
             _ => unreachable!("record_size is validated in Reader::from_source"),
         }
     }

--- a/src/reader_test.rs
+++ b/src/reader_test.rs
@@ -1513,6 +1513,25 @@ fn test_serde_flatten() {
 }
 
 #[test]
+fn test_network_iteration_rejects_internal_node_cycle() {
+    let mut reader = open_test_data_reader("MaxMind-DB-test-ipv4-24.mmdb");
+
+    // Make both branches of the root node point back to the root. Opening the
+    // original database already populated all layout invariants, so this
+    // isolates iterator behavior on a corrupt tree without building a fixture.
+    reader.buf[..6].fill(0);
+
+    let err = reader
+        .networks(Default::default())
+        .unwrap()
+        .next()
+        .expect("cyclic tree should yield an error")
+        .unwrap_err();
+    assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+    assert!(err.to_string().contains("address bit length"));
+}
+
+#[test]
 fn test_verify_follows_and_rejects_invalid_data_pointers() {
     let mut reader = open_test_data_reader("MaxMind-DB-test-ipv4-24.mmdb");
     let data_offset = reader

--- a/src/reader_test.rs
+++ b/src/reader_test.rs
@@ -1511,3 +1511,22 @@ fn test_serde_flatten() {
     let result: PartialCountry = lookup.decode().unwrap().unwrap();
     assert_eq!(result.continent.code, "EU");
 }
+
+#[test]
+fn test_verify_follows_and_rejects_invalid_data_pointers() {
+    let mut reader = open_test_data_reader("MaxMind-DB-test-ipv4-24.mmdb");
+    let data_offset = reader
+        .lookup("1.1.1.1".parse().unwrap())
+        .unwrap()
+        .offset()
+        .unwrap();
+    let record_start = reader.pointer_base + data_offset;
+
+    // Replace the record with a four-byte data pointer to u32::MAX, which is
+    // outside this database's data section.
+    reader.buf[record_start..record_start + 5].copy_from_slice(&[0x38, 0xff, 0xff, 0xff, 0xff]);
+
+    let err = reader.verify().unwrap_err();
+    assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+    assert!(err.to_string().contains("unexpected end of buffer"));
+}

--- a/src/result.rs
+++ b/src/result.rs
@@ -256,17 +256,15 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
 
             match *element {
                 PathElement::Key(key) => {
-                    let (_, type_num) = decoder.peek_type().map_err(with_path)?;
+                    let header_offset = decoder.offset();
+                    let (size, type_num) = decoder.consume_container_header().map_err(with_path)?;
                     if type_num != TYPE_MAP {
                         return Err(MaxMindDbError::decoding_at_path(
                             format!("expected map for Key(\"{key}\"), got type {type_num}"),
-                            decoder.offset(),
+                            header_offset,
                             render_path(&path[..=i]),
                         ));
                     }
-
-                    // Consume the map header and get size
-                    let size = decoder.consume_map_header().map_err(with_path)?;
 
                     let mut found = false;
                     let key_bytes = key.as_bytes();
@@ -286,7 +284,8 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
                     }
                 }
                 PathElement::Index(idx) | PathElement::IndexFromEnd(idx) => {
-                    let (_, type_num) = decoder.peek_type().map_err(with_path)?;
+                    let header_offset = decoder.offset();
+                    let (size, type_num) = decoder.consume_container_header().map_err(with_path)?;
                     if type_num != TYPE_ARRAY {
                         let elem = match *element {
                             PathElement::Index(i) => format!("Index({i})"),
@@ -295,13 +294,10 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
                         };
                         return Err(MaxMindDbError::decoding_at_path(
                             format!("expected array for {elem}, got type {type_num}"),
-                            decoder.offset(),
+                            header_offset,
                             render_path(&path[..=i]),
                         ));
                     }
-
-                    // Consume the array header and get size
-                    let size = decoder.consume_array_header().map_err(with_path)?;
 
                     if idx >= size {
                         return Ok(None); // Out of bounds
@@ -353,7 +349,7 @@ fn render_path(path: &[PathElement<'_>]) -> String {
         match elem {
             PathElement::Key(k) => s.push_str(k),
             PathElement::Index(i) => write!(s, "{i}").unwrap(),
-            PathElement::IndexFromEnd(i) => write!(s, "{}", -((*i as isize) + 1)).unwrap(),
+            PathElement::IndexFromEnd(i) => write!(s, "-{}", (*i as u128) + 1).unwrap(),
         }
     }
     s
@@ -674,6 +670,14 @@ mod tests {
         assert_eq!(
             render_path(&[PathElement::Key("arr"), PathElement::IndexFromEnd(1)]),
             "/arr/-2"
+        );
+        assert_eq!(
+            render_path(&[PathElement::IndexFromEnd(isize::MAX as usize)]),
+            format!("/-{}", (isize::MAX as u128) + 1)
+        );
+        assert_eq!(
+            render_path(&[PathElement::IndexFromEnd(usize::MAX)]),
+            format!("/-{}", (usize::MAX as u128) + 1)
         );
     }
 

--- a/src/within.rs
+++ b/src/within.rs
@@ -224,6 +224,11 @@ impl<'de, S: AsRef<[u8]>> Iterator for Within<'de, S> {
                     // Otherwise skip (current behavior)
                 }
                 Ordering::Less => {
+                    if current.prefix_len >= bit_count {
+                        return Some(Err(MaxMindDbError::invalid_database(
+                            "search tree appears to have a cycle or invalid structure (traversal exceeded the address bit length)",
+                        )));
+                    }
                     // In order traversal of our children
                     // right/1-bit
                     let mut right_ip_int = current.ip_int;


### PR DESCRIPTION
## Summary

- harden metadata, search-tree, decoder, and path validation for malformed databases
- bound verification of shared pointer graphs and reject data-pointer cycles
- prevent cyclic search-tree iteration and improve path error handling
- exercise mmap, simdutf8, and unsafe string feature combinations without executing benchmarks in CI
- remove decoder logging overhead and retain benchmarked lookup/iteration cleanups

## Validation

- cargo test with default, mmap, mmap plus simdutf8, unsafe-str-decode, and mmap plus unsafe-str-decode configurations
- clean-checkout feature matrix without the ignored root GeoLite database
- cargo clippy --all-targets --features mmap,simdutf8 -- -D warnings
- cargo doc --no-deps
- Criterion comparisons for lookup, standard city/country/empty decoding, reader construction, and network iteration

Standard lookup and decoding remain performance-neutral overall. Reader construction was neutral, city iteration was neutral, and mixed-tree iteration improved by about 2.9%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of cyclic/invalid database structures during network iteration and verification.
  * Strengthened validation for invalid pointers/encodings and impossible container sizes.
  * Enhanced `decode_path()` navigation and error rendering for extreme indexes, with more accurate mismatch offsets.
  * Reduced misleading size hints during record iteration.
* **Performance**
  * Faster verification and path/skip handling via more efficient decoding.
* **Documentation**
  * Updated **Unreleased** changelog with the latest fixes.
* **Testing**
  * Added regression tests for corruption handling and expanded CI feature coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->