### PR TITLE
Fix malformed extended types and add fuzzing

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,6 +8,10 @@ on:
     - cron: "0 8 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -19,12 +23,13 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,44 @@
+name: Fuzz
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Fuzz standalone values
+        run: >-
+          cargo fuzz run decode --
+          -max_total_time=${{ github.event_name == 'schedule' && '300' || '30' }}
+          -max_len=4096
+          -timeout=5
+
+      - name: Fuzz reader operations
+        run: >-
+          cargo fuzz run reader --
+          -max_total_time=${{ github.event_name == 'schedule' && '300' || '30' }}
+          -max_len=32768
+          -timeout=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.30.3 - 2026-08-23
+
+- Fixed typed decoding of malformed overflowing extended types to consistently
+  return an `InvalidDatabase` error.
+
 ## 0.30.2 - 2026-08-23
 
 - No user-visible changes. This release republishes 0.30.1 because its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.30.2 - 2026-08-23
 
+- No user-visible changes. This release republishes 0.30.1 because its
+  immutable GitHub release was deleted.
+
+## 0.30.1 - 2026-08-23
+
 - Fixed malformed extended data types so decoding returns an
   `InvalidDatabase` error instead of panicking on `u8` overflow. GitHub #122.
 - Added cargo-fuzz targets for standalone data values and public reader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 0.30.1 - 2026-08-23
 
 - Fixed malformed extended data types so decoding returns an
   `InvalidDatabase` error instead of panicking on `u8` overflow. GitHub #122.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Fixed malformed extended data types so decoding returns an
+  `InvalidDatabase` error instead of panicking on `u8` overflow. GitHub #122.
+
 ## 0.30.0 - 2026-07-18
 
 - Added `deserialize_any_with_raw_strings()` for Serde-based format adapters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.30.1 - 2026-08-23
+## 0.30.2 - 2026-08-23
 
 - Fixed malformed extended data types so decoding returns an
   `InvalidDatabase` error instead of panicking on `u8` overflow. GitHub #122.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed malformed extended data types so decoding returns an
   `InvalidDatabase` error instead of panicking on `u8` overflow. GitHub #122.
+- Added cargo-fuzz targets for standalone data values and public reader
+  operations, including a bounded CI fuzzing job.
 
 ## 0.30.0 - 2026-07-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maxminddb"
-version = "0.30.2"
+version = "0.30.3"
 authors = [ "Gregory J. Oschwald <oschwald@gmail.com>" ]
 description = "Library for reading MaxMind DB format used by GeoIP2 and GeoLite2"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ mmap = ["memmap2"]
 # Skip UTF-8 validation for trusted Rust-native string decoding
 # (mutually exclusive with simdutf8)
 unsafe-str-decode = []
+# Internal entry points used by the cargo-fuzz targets.
+fuzzing = []
 
 [lib]
 name = "maxminddb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maxminddb"
-version = "0.30.1"
+version = "0.30.2"
 authors = [ "Gregory J. Oschwald <oschwald@gmail.com>" ]
 description = "Library for reading MaxMind DB format used by GeoIP2 and GeoLite2"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maxminddb"
-version = "0.30.0"
+version = "0.30.1"
 authors = [ "Gregory J. Oschwald <oschwald@gmail.com>" ]
 description = "Library for reading MaxMind DB format used by GeoIP2 and GeoLite2"
 readme = "README.md"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "maxminddb-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde = "1.0"
+
+[dependencies.maxminddb]
+path = ".."
+features = ["fuzzing"]
+
+[[bin]]
+name = "decode"
+path = "fuzz_targets/decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "reader"
+path = "fuzz_targets/reader.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -12,10 +12,11 @@ cargo +nightly fuzz run reader
 ```
 
 `decode` sends arbitrary data-section values through both Serde decoding and
-database verification. `reader` exercises database opening, verification,
-lookups, full decoding, path decoding, and network iteration. It tests each
-input both as an arbitrary database and as mutations to a small valid database,
-which lets the fuzzer reach deeper parsing paths without a separate seed corpus.
+the data-value verification decoder. `reader` exercises database opening,
+verification, lookups, full decoding, path decoding, and network iteration. It
+tests each input both as an arbitrary database and as mutations to a small valid
+database, which lets the fuzzer reach deeper parsing paths without a separate
+seed corpus.
 
 For a bounded local smoke test, pass libFuzzer options after `--`:
 
@@ -24,6 +25,11 @@ cargo +nightly fuzz run decode -- -max_total_time=30
 cargo +nightly fuzz run reader -- -max_total_time=30
 ```
 
-Crashes are written under `fuzz/artifacts/`. Minimize a crash with `cargo fuzz
-tmin`, then add the minimized input or an equivalent focused case to the normal
-test suite as a permanent regression test.
+Crashes are written under `fuzz/artifacts/`. Minimize a crash with:
+
+```console
+cargo +nightly fuzz tmin <target> fuzz/artifacts/<target>/<crash-file>
+```
+
+Then add the minimized input or an equivalent focused case to the normal test
+suite as a permanent regression test.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,29 @@
+# Fuzzing
+
+The fuzz suite uses [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) and
+requires a nightly Rust toolchain.
+
+Install the runner and execute either target from the repository root:
+
+```console
+cargo install cargo-fuzz --locked
+cargo +nightly fuzz run decode
+cargo +nightly fuzz run reader
+```
+
+`decode` sends arbitrary data-section values through both Serde decoding and
+database verification. `reader` exercises database opening, verification,
+lookups, full decoding, path decoding, and network iteration. It tests each
+input both as an arbitrary database and as mutations to a small valid database,
+which lets the fuzzer reach deeper parsing paths without a separate seed corpus.
+
+For a bounded local smoke test, pass libFuzzer options after `--`:
+
+```console
+cargo +nightly fuzz run decode -- -max_total_time=30
+cargo +nightly fuzz run reader -- -max_total_time=30
+```
+
+Crashes are written under `fuzz/artifacts/`. Minimize a crash with `cargo fuzz
+tmin`, then add the minimized input or an equivalent focused case to the normal
+test suite as a permanent regression test.

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -1,0 +1,126 @@
+use std::fmt;
+
+use serde::de::{self, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde::Deserialize;
+
+pub(crate) struct FuzzValue;
+
+impl<'de> Deserialize<'de> for FuzzValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(FuzzValueVisitor)
+    }
+}
+
+struct FuzzValueVisitor;
+
+impl<'de> Visitor<'de> for FuzzValueVisitor {
+    type Value = FuzzValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a MaxMind DB value")
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_i32<E>(self, _value: i32) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_u16<E>(self, _value: u16) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_u32<E>(self, _value: u32) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_u128<E>(self, _value: u128) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_f32<E>(self, _value: f32) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_borrowed_str<E>(self, _value: &'de str) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_borrowed_bytes<E>(self, _value: &'de [u8]) -> Result<Self::Value, E> {
+        Ok(FuzzValue)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while sequence.next_element::<FuzzValue>()?.is_some() {}
+        Ok(FuzzValue)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        while map.next_key::<FuzzIdentifier>()?.is_some() {
+            map.next_value::<FuzzValue>()?;
+        }
+        Ok(FuzzValue)
+    }
+}
+
+struct FuzzIdentifier;
+
+impl<'de> Deserialize<'de> for FuzzIdentifier {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_identifier(FuzzIdentifierVisitor)
+    }
+}
+
+struct FuzzIdentifierVisitor;
+
+impl<'de> Visitor<'de> for FuzzIdentifierVisitor {
+    type Value = FuzzIdentifier;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a MaxMind DB map key")
+    }
+
+    fn visit_borrowed_str<E>(self, _value: &'de str) -> Result<Self::Value, E> {
+        Ok(FuzzIdentifier)
+    }
+
+    fn visit_borrowed_bytes<E>(self, _value: &'de [u8]) -> Result<Self::Value, E> {
+        Ok(FuzzIdentifier)
+    }
+
+    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(FuzzIdentifier)
+    }
+
+    fn visit_bytes<E>(self, _value: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(FuzzIdentifier)
+    }
+}

--- a/fuzz/fuzz_targets/decode.rs
+++ b/fuzz/fuzz_targets/decode.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+mod common;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = maxminddb::fuzzing::decode::<common::FuzzValue>(data);
+    let _ = maxminddb::fuzzing::verify(data);
+});

--- a/fuzz/fuzz_targets/reader.rs
+++ b/fuzz/fuzz_targets/reader.rs
@@ -1,0 +1,68 @@
+#![no_main]
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use libfuzzer_sys::fuzz_target;
+use maxminddb::{LookupResult, PathElement, Reader, WithinOptions};
+
+mod common;
+
+const SEED_DATABASE: &[u8] =
+    include_bytes!("../../test-data/test-data/MaxMind-DB-test-ipv4-24.mmdb");
+
+fn exercise_lookup<S>(lookup: &LookupResult<'_, S>)
+where
+    S: AsRef<[u8]>,
+{
+    let _ = lookup.network();
+    let _ = lookup.decode::<common::FuzzValue>();
+
+    let map_path = [PathElement::Key("country"), PathElement::Key("iso_code")];
+    let _ = lookup.decode_path::<common::FuzzValue>(&map_path);
+
+    let array_path = [PathElement::Key("array"), PathElement::Index(0)];
+    let _ = lookup.decode_path::<common::FuzzValue>(&array_path);
+}
+
+fn exercise_database(data: &[u8]) {
+    let Ok(reader) = Reader::from_source(data) else {
+        return;
+    };
+
+    let _ = reader.verify();
+
+    let addresses = [
+        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(89, 160, 20, 128)),
+        IpAddr::V4(Ipv4Addr::BROADCAST),
+        IpAddr::V6(Ipv6Addr::LOCALHOST),
+        IpAddr::V6(Ipv6Addr::from(u128::MAX)),
+    ];
+    for address in addresses {
+        if let Ok(lookup) = reader.lookup(address) {
+            exercise_lookup(&lookup);
+        }
+    }
+
+    if let Ok(networks) = reader.networks(WithinOptions::default()) {
+        for lookup in networks.take(256).flatten() {
+            exercise_lookup(&lookup);
+        }
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Exercise arbitrary files for parser and metadata coverage.
+    exercise_database(data);
+
+    // Also interpret the input as byte patches against a valid tiny database.
+    // This keeps enough structure intact for mutations to reach search-tree and
+    // data-section decoding quickly, without needing a checked-in corpus copy.
+    let mut database = SEED_DATABASE.to_vec();
+    for patch in data.chunks_exact(3) {
+        let offset = usize::from(u16::from_be_bytes([patch[0], patch[1]])) % database.len();
+        database[offset] = patch[2];
+    }
+    exercise_database(&database);
+});

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -18,20 +18,20 @@ use std::convert::TryInto;
 use crate::error::MaxMindDbError;
 
 // MaxMind DB type constants
-const TYPE_EXTENDED: u8 = 0;
-pub(crate) const TYPE_POINTER: u8 = 1;
-const TYPE_STRING: u8 = 2;
-const TYPE_DOUBLE: u8 = 3;
-const TYPE_BYTES: u8 = 4;
-const TYPE_UINT16: u8 = 5;
-const TYPE_UINT32: u8 = 6;
-pub(crate) const TYPE_MAP: u8 = 7;
-const TYPE_INT32: u8 = 8;
-const TYPE_UINT64: u8 = 9;
-const TYPE_UINT128: u8 = 10;
-pub(crate) const TYPE_ARRAY: u8 = 11;
-const TYPE_BOOL: u8 = 14;
-const TYPE_FLOAT: u8 = 15;
+const TYPE_EXTENDED: usize = 0;
+pub(crate) const TYPE_POINTER: usize = 1;
+const TYPE_STRING: usize = 2;
+const TYPE_DOUBLE: usize = 3;
+const TYPE_BYTES: usize = 4;
+const TYPE_UINT16: usize = 5;
+const TYPE_UINT32: usize = 6;
+pub(crate) const TYPE_MAP: usize = 7;
+const TYPE_INT32: usize = 8;
+const TYPE_UINT64: usize = 9;
+const TYPE_UINT128: usize = 10;
+pub(crate) const TYPE_ARRAY: usize = 11;
+const TYPE_BOOL: usize = 14;
+const TYPE_FLOAT: usize = 15;
 
 const RAW_STRINGS_NEWTYPE: &str = "$maxminddb::raw_strings";
 
@@ -172,7 +172,7 @@ impl<'de> Decoder<'de> {
     }
 
     #[inline(always)]
-    fn type_mismatch(&self, label: &str, type_num: u8) -> MaxMindDbError {
+    fn type_mismatch(&self, label: &str, type_num: usize) -> MaxMindDbError {
         self.decode_error(&format!("expected {label}, got type {type_num}"))
     }
 
@@ -224,7 +224,7 @@ impl<'de> Decoder<'de> {
     }
 
     #[inline(always)]
-    fn size_from_ctrl_byte(&mut self, ctrl_byte: u8, type_num: u8) -> DecodeResult<usize> {
+    fn size_from_ctrl_byte(&mut self, ctrl_byte: u8, type_num: usize) -> DecodeResult<usize> {
         let size = (ctrl_byte & 0x1f) as usize;
         // Extended type - size field is used differently
         if type_num == TYPE_EXTENDED {
@@ -249,12 +249,13 @@ impl<'de> Decoder<'de> {
     }
 
     #[inline(always)]
-    fn size_and_type(&mut self) -> DecodeResult<(usize, u8)> {
+    fn size_and_type(&mut self) -> DecodeResult<(usize, usize)> {
         let ctrl_byte = self.eat_byte()?;
-        let mut type_num = ctrl_byte >> 5;
+        let mut type_num = usize::from(ctrl_byte >> 5);
         // Extended type: type 0 means read next byte for actual type
         if type_num == TYPE_EXTENDED {
-            type_num = self.eat_byte()? + TYPE_MAP; // Extended types start at 7
+            // Widen before adding so malformed bytes cannot overflow.
+            type_num = usize::from(self.eat_byte()?) + TYPE_MAP;
         }
         let size = self.size_from_ctrl_byte(ctrl_byte, type_num)?;
         Ok((size, type_num))
@@ -543,7 +544,7 @@ impl<'de> Decoder<'de> {
 
     /// Peeks at the type and size without consuming it.
     /// Returns (size, type_num) and restores the position.
-    pub(crate) fn peek_type(&mut self) -> DecodeResult<(usize, u8)> {
+    pub(crate) fn peek_type(&mut self) -> DecodeResult<(usize, usize)> {
         let saved_ptr = self.current_ptr;
         let result = self.size_and_type_following_pointers()?;
         self.current_ptr = saved_ptr;
@@ -551,12 +552,12 @@ impl<'de> Decoder<'de> {
     }
 
     /// Consumes a map or array header in one pass, following a pointer if needed.
-    pub(crate) fn consume_container_header(&mut self) -> DecodeResult<(usize, u8)> {
+    pub(crate) fn consume_container_header(&mut self) -> DecodeResult<(usize, usize)> {
         self.size_and_type_following_pointers()
     }
 
     /// Gets size and type, following any pointers.
-    fn size_and_type_following_pointers(&mut self) -> DecodeResult<(usize, u8)> {
+    fn size_and_type_following_pointers(&mut self) -> DecodeResult<(usize, usize)> {
         let (size, type_num) = self.size_and_type()?;
         if type_num != TYPE_POINTER {
             return Ok((size, type_num));
@@ -575,8 +576,8 @@ impl<'de> Decoder<'de> {
     fn decode_direct<T, F>(
         &mut self,
         size: usize,
-        type_num: u8,
-        expected_type: u8,
+        type_num: usize,
+        expected_type: usize,
         label: &str,
         decode: F,
     ) -> DecodeResult<T>
@@ -744,7 +745,12 @@ impl<'de> Decoder<'de> {
     }
 
     #[inline(always)]
-    fn skip_value_inner(&mut self, size: usize, type_num: u8, skip_depth: u16) -> DecodeResult<()> {
+    fn skip_value_inner(
+        &mut self,
+        size: usize,
+        type_num: usize,
+        skip_depth: u16,
+    ) -> DecodeResult<()> {
         // Headers and scalar payloads validate every cursor advance. A
         // successful recursive skip therefore already guarantees that the
         // cursor remains within the decoder limit.
@@ -841,7 +847,7 @@ impl<'de> Decoder<'de> {
     fn skip_value_inner_for_verification(
         &mut self,
         size: usize,
-        type_num: u8,
+        type_num: usize,
         skip_depth: u16,
         state: &mut VerificationState,
     ) -> DecodeResult<()> {
@@ -1611,6 +1617,21 @@ mod tests {
         let mut unknown_decoder = Decoder::new(&[0x00, 0x06], 0);
         let type_err = RawValueSeed.deserialize(&mut unknown_decoder).unwrap_err();
         assert!(type_err.to_string().contains("unknown data type: 13"));
+    }
+
+    #[test]
+    fn malformed_extended_types_return_errors_instead_of_overflowing() {
+        for extended_type in 249..=u8::MAX {
+            let encoded = [0x00, extended_type];
+            let mut decoder = Decoder::new(&encoded, 0);
+            let error = RawValueSeed.deserialize(&mut decoder).unwrap_err();
+
+            assert!(matches!(error, MaxMindDbError::InvalidDatabase { .. }));
+            assert!(error.to_string().contains(&format!(
+                "unknown data type: {}",
+                u16::from(extended_type) + 7
+            )));
+        }
     }
 
     #[test]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -173,7 +173,11 @@ impl<'de> Decoder<'de> {
 
     #[inline(always)]
     fn type_mismatch(&self, label: &str, type_num: usize) -> MaxMindDbError {
-        self.decode_error(&format!("expected {label}, got type {type_num}"))
+        if type_num > usize::from(u8::MAX) {
+            self.invalid_db_error(&format!("unknown data type: {type_num}"))
+        } else {
+            self.decode_error(&format!("expected {label}, got type {type_num}"))
+        }
     }
 
     #[inline]
@@ -1631,6 +1635,14 @@ mod tests {
                 "unknown data type: {}",
                 u16::from(extended_type) + 7
             )));
+
+            let mut typed_decoder = Decoder::new(&encoded, 0);
+            let typed_error =
+                <u32 as serde::Deserialize>::deserialize(&mut typed_decoder).unwrap_err();
+            assert!(matches!(
+                typed_error,
+                MaxMindDbError::InvalidDatabase { .. }
+            ));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,29 @@ pub use within::{Within, WithinOptions};
 #[cfg(feature = "mmap")]
 pub use memmap2::Mmap;
 
+/// Internal entry points for the cargo-fuzz targets.
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub mod fuzzing {
+    use serde::Deserialize;
+
+    use crate::decoder::{Decoder, VerificationState};
+    use crate::MaxMindDbError;
+
+    /// Deserialize one data-section value through the Serde decoder.
+    pub fn decode<'de, T>(data: &'de [u8]) -> Result<T, MaxMindDbError>
+    where
+        T: Deserialize<'de>,
+    {
+        T::deserialize(&mut Decoder::new(data, 0))
+    }
+
+    /// Validate one data-section value through the verification decoder.
+    pub fn verify(data: &[u8]) -> Result<(), MaxMindDbError> {
+        Decoder::new(data, 0).skip_value_for_verification(&mut VerificationState::default())
+    }
+}
+
 #[cfg(test)]
 mod reader_test;
 

--- a/src/reader_test.rs
+++ b/src/reader_test.rs
@@ -1215,7 +1215,8 @@ fn test_rejects_data_pointer_to_metadata_marker() {
     assert!(pointer <= 0x00ff_ffff);
 
     let mut bytes = std::fs::read(source_path).unwrap();
-    for record in bytes[..6].chunks_exact_mut(3) {
+    for record_start in [0, 3] {
+        let record = &mut bytes[record_start..record_start + 3];
         record[0] = ((pointer >> 16) & 0xff) as u8;
         record[1] = ((pointer >> 8) & 0xff) as u8;
         record[2] = (pointer & 0xff) as u8;

--- a/src/result.rs
+++ b/src/result.rs
@@ -259,10 +259,11 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
                     let header_offset = decoder.offset();
                     let (size, type_num) = decoder.consume_container_header().map_err(with_path)?;
                     if type_num != TYPE_MAP {
-                        return Err(MaxMindDbError::decoding_at_path(
-                            format!("expected map for Key(\"{key}\"), got type {type_num}"),
+                        return Err(container_type_mismatch(
+                            type_num,
                             header_offset,
-                            render_path(&path[..=i]),
+                            &path[..=i],
+                            format!("expected map for Key(\"{key}\"), got type {type_num}"),
                         ));
                     }
 
@@ -292,10 +293,11 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
                             PathElement::IndexFromEnd(i) => format!("IndexFromEnd({i})"),
                             PathElement::Key(_) => unreachable!(),
                         };
-                        return Err(MaxMindDbError::decoding_at_path(
-                            format!("expected array for {elem}, got type {type_num}"),
+                        return Err(container_type_mismatch(
+                            type_num,
                             header_offset,
-                            render_path(&path[..=i]),
+                            &path[..=i],
+                            format!("expected array for {elem}, got type {type_num}"),
                         ));
                     }
 
@@ -321,6 +323,20 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
         T::deserialize(&mut decoder)
             .map(Some)
             .map_err(|e| add_path_context(e, path))
+    }
+}
+
+#[cold]
+fn container_type_mismatch(
+    type_num: usize,
+    offset: usize,
+    path: &[PathElement<'_>],
+    message: String,
+) -> MaxMindDbError {
+    if type_num > usize::from(u8::MAX) {
+        MaxMindDbError::invalid_database_at(format!("unknown data type: {type_num}"), offset)
+    } else {
+        MaxMindDbError::decoding_at_path(message, offset, render_path(path))
     }
 }
 
@@ -712,5 +728,18 @@ mod tests {
             err_str.contains("path: /city/0"),
             "error should include full path to failure: {err_str}"
         );
+    }
+
+    #[test]
+    fn test_overflowing_extended_navigation_type_is_invalid_database() {
+        let err = container_type_mismatch(
+            256,
+            7,
+            &[PathElement::Key("city")],
+            "unused mismatch".to_owned(),
+        );
+
+        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(err.to_string().contains("unknown data type: 256"));
     }
 }


### PR DESCRIPTION
## Summary

- widen decoded type arithmetic so malformed extended types return InvalidDatabase instead of panicking or wrapping
- add regression coverage for every overflowing extended type byte
- add cargo-fuzz targets for standalone values and public Reader operations
- add bounded pull-request fuzz smoke tests and longer weekly fuzz runs
- document the fuzzing workflow and add changelog entries

Closes #122.

## Compatibility and performance

This is non-breaking. The changed decoder types and signatures are crate-private, valid MMDB behavior is unchanged, and the fuzzing entry points are behind an additive feature that is disabled by default.

The final implementation widens the type before addition, avoiding an extra conditional branch in valid decoding. Criterion detected no decode regression; decode_city_only measured -0.72% to +0.15% against the saved baseline, while the other decode and path cases measured faster.

## Verification

- cargo test
- cargo test --features mmap,simdutf8
- cargo test --features unsafe-str-decode
- cargo test --release malformed_extended_types_return_errors_instead_of_overflowing
- cargo clippy --all-targets --features mmap,simdutf8 -- -D warnings
- cargo clippy --manifest-path fuzz/Cargo.toml --bins -- -D warnings
- cargo doc --no-deps --features mmap,simdutf8
- cargo fuzz build decode
- cargo fuzz build reader
- 30-minute decode fuzz run: 131,472,456 executions, 4,029 new units, no failures or slow inputs
- 30-minute reader fuzz run: 32,453,989 executions, 14,908 new units, no failures or slow inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed extended data now returns an `InvalidDatabase` error instead of causing an overflow or panic.
  * Improved resilience when processing corrupted or unexpected database content.

* **Quality Improvements**
  * Added automated fuzz testing for database decoding, verification, lookups, and network iteration.
  * Added regression coverage for malformed database structures and invalid type data.

* **Documentation**
  * Updated the changelog with the decoding fix and expanded validation coverage.
  * Added guidance for reproducing, minimizing, and regression-testing discovered crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->