### PR TITLE
Bound decoding and verification to prevent amplification

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,3 +97,6 @@ jobs:
 
       - name: Run cargo clippy
         run: cargo clippy --all-targets --features mmap,simdutf8 -- -D warnings
+
+      - name: Test release helpers
+        run: bash dev-bin/release-lib-test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Limited subdivision lists in the built-in City and Enterprise types to 32
   entries to prevent excessive allocation from untrusted data.
 - `Reader::verify()` now checks data referenced by unknown metadata fields.
+- Improved record decoding performance by accelerating short ASCII string
+  validation and inlining decoding entry points.
 
 ## 0.30.3 - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.31.0
+
+- Fixed a denial-of-service issue when decoding records or metadata. A
+  crafted database could repeatedly reference shared data, causing excessive
+  CPU and memory use. Decoding now limits the number of values and the amount
+  of string and byte data expanded in a single operation. Operations that
+  exceed these limits return `MaxMindDbError::ResourceLimit`.
+
 ## 0.30.3 - 2026-08-23
 
 - Fixed typed decoding of malformed overflowing extended types to consistently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   CPU and memory use. Decoding now limits the number of values and the amount
   of string and byte data expanded in a single operation. Operations that
   exceed these limits return `MaxMindDbError::ResourceLimit`.
+- Limited subdivision lists in the built-in City and Enterprise types to 32
+  entries to prevent excessive allocation from untrusted data.
 
 ## 0.30.3 - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   exceed these limits return `MaxMindDbError::ResourceLimit`.
 - Limited subdivision lists in the built-in City and Enterprise types to 32
   entries to prevent excessive allocation from untrusted data.
+- `Reader::verify()` now checks data referenced by unknown metadata fields.
 
 ## 0.30.3 - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Limited subdivision lists in the built-in City and Enterprise types to 32
   entries to prevent excessive allocation from untrusted data.
 - `Reader::verify()` now checks data referenced by unknown metadata fields.
+- Limited the work performed by `Reader::verify()` to prevent excessive CPU
+  use from databases with overlapping string payloads. Verification returns
+  `MaxMindDbError::ResourceLimit` when this limit is exceeded.
 - Improved record decoding performance by accelerating short ASCII string
   validation and inlining decoding entry points.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maxminddb"
-version = "0.30.3"
+version = "0.31.0"
 authors = [ "Gregory J. Oschwald <oschwald@gmail.com>" ]
 description = "Library for reading MaxMind DB format used by GeoIP2 and GeoLite2"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-maxminddb = "0.30"
+maxminddb = "0.31"
 ```
 
 Enable optional features as needed:
 
 ```toml
 [dependencies]
-maxminddb = { version = "0.30", features = ["mmap"] }
+maxminddb = { version = "0.31", features = ["mmap"] }
 ```
 
 ## Example
@@ -116,7 +116,7 @@ Enable in `Cargo.toml`:
 
 ```toml
 [dependencies]
-maxminddb = { version = "0.30", features = ["mmap"] }
+maxminddb = { version = "0.31", features = ["mmap"] }
 ```
 
 Note: `simdutf8` and `unsafe-str-decode` are mutually exclusive.

--- a/dev-bin/release-lib-test.sh
+++ b/dev-bin/release-lib-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+release_test_script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$release_test_script_dir/release-lib.sh"
+
+release_test_dir=$(mktemp -d)
+trap 'rm -rf -- "$release_test_dir"' EXIT
+
+fail() {
+    echo "release helper test failed: $*" >&2
+    exit 1
+}
+
+supported_readme="$release_test_dir/supported.md"
+printf '%s\n' \
+    'maxminddb = "0.29"' \
+    'maxminddb = { version = "0.30", features = ["mmap"] }' \
+    'maxminddb = { features = ["simdutf8"], version = "0.28" }' \
+    'other = { version = "9.99" }' \
+    >"$supported_readme"
+
+update_readme_dependency_versions "$supported_readme" "0.31"
+
+[ "$(grep -Fc 'maxminddb = "0.31"' "$supported_readme")" -eq 1 ] ||
+    fail "plain dependency was not updated"
+[ "$(grep -Ec '^maxminddb = \{.*version = "0.31"' "$supported_readme")" -eq 2 ] ||
+    fail "inline-table dependencies were not updated"
+grep -Fxq 'other = { version = "9.99" }' "$supported_readme" ||
+    fail "an unrelated version was changed"
+
+unsupported_readme="$release_test_dir/unsupported.md"
+printf '%s\n' 'maxminddb = { path = "../maxminddb" }' >"$unsupported_readme"
+if (update_readme_dependency_versions "$unsupported_readme" "0.31") \
+    2>"$release_test_dir/unsupported.err"; then
+    fail "an unsupported dependency form was accepted"
+fi
+grep -Fq 'Not every maxminddb dependency example' "$release_test_dir/unsupported.err" ||
+    fail "unsupported dependency form did not produce an actionable error"
+
+mixed_readme="$release_test_dir/mixed.md"
+printf '%s\n' \
+    'maxminddb = "0.29"' \
+    'maxminddb = { path = "../maxminddb" }' \
+    >"$mixed_readme"
+cp "$mixed_readme" "$release_test_dir/mixed.before"
+if (update_readme_dependency_versions "$mixed_readme" "0.31") \
+    2>"$release_test_dir/mixed.err"; then
+    fail "mixed supported and unsupported dependency forms were accepted"
+fi
+cmp -s "$release_test_dir/mixed.before" "$mixed_readme" ||
+    fail "a failed update partially modified the README"
+
+missing_readme="$release_test_dir/missing.md"
+printf '%s\n' 'other = "1.0"' >"$missing_readme"
+if (update_readme_dependency_versions "$missing_readme" "0.31") \
+    2>"$release_test_dir/missing.err"; then
+    fail "a README without maxminddb examples was accepted"
+fi
+grep -Fq 'Could not find any maxminddb dependency examples' "$release_test_dir/missing.err" ||
+    fail "missing dependency examples did not produce an actionable error"

--- a/dev-bin/release-lib.sh
+++ b/dev-bin/release-lib.sh
@@ -1,0 +1,55 @@
+update_readme_dependency_versions() {
+    local file=$1
+    local dependency_version=$2
+    local dependency_pattern='^[[:space:]]*maxminddb[[:space:]]*='
+    local dependency_count
+    local expected_count
+    local supported_count
+    local temporary_file
+
+    # grep reports status 1 for a valid search with no matches. Preserve its
+    # count so the explicit checks below can emit useful release diagnostics.
+    dependency_count=$(grep -Ec "$dependency_pattern" "$file" || true)
+    if [ "$dependency_count" -eq 0 ]; then
+        echo "Could not find any maxminddb dependency examples in $file!" >&2
+        return 1
+    fi
+
+    supported_count=$(grep -Ec \
+        "${dependency_pattern}[[:space:]]*(\"[0-9]+\.[0-9]+\"|\{[^}]*version[[:space:]]*=[[:space:]]*\"[0-9]+\.[0-9]+\")" \
+        "$file" || true)
+    if [ "$supported_count" -ne "$dependency_count" ]; then
+        echo "Not every maxminddb dependency example in $file uses a supported version form:" >&2
+        grep -nE "$dependency_pattern" "$file" >&2
+        return 1
+    fi
+
+    temporary_file=$(mktemp "${file}.tmp.XXXXXX") || return 1
+    if ! cp -p -- "$file" "$temporary_file"; then
+        rm -f -- "$temporary_file"
+        return 1
+    fi
+
+    if ! sed -i -E \
+        -e "s/(^[[:space:]]*maxminddb[[:space:]]*=[[:space:]]*\")[0-9]+\.[0-9]+(\")/\1${dependency_version}\2/" \
+        -e "/$dependency_pattern/ s/(version[[:space:]]*=[[:space:]]*\")[0-9]+\.[0-9]+(\")/\1${dependency_version}\2/" \
+        "$temporary_file"; then
+        rm -f -- "$temporary_file"
+        return 1
+    fi
+
+    expected_count=$(grep -Ec \
+        "${dependency_pattern}[[:space:]]*(\"${dependency_version}\"|\{.*version[[:space:]]*=[[:space:]]*\"${dependency_version}\")" \
+        "$temporary_file" || true)
+    if [ "$expected_count" -ne "$dependency_count" ]; then
+        echo "Not every maxminddb dependency example in $file uses version $dependency_version:" >&2
+        grep -nE "$dependency_pattern" "$temporary_file" >&2
+        rm -f -- "$temporary_file"
+        return 1
+    fi
+
+    if ! mv -- "$temporary_file" "$file"; then
+        rm -f -- "$temporary_file"
+        return 1
+    fi
+}

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -2,6 +2,9 @@
 
 set -eu -o pipefail
 
+release_script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$release_script_dir/release-lib.sh"
+
 # Check that we're not on the main branch
 current_branch=$(git branch --show-current)
 if [ "$current_branch" = "main" ]; then
@@ -50,6 +53,8 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
+trap 'git restore --source=HEAD --staged --worktree -- Cargo.toml README.md' EXIT
+
 # Update version in Cargo.toml
 current_cargo_version=$(grep -E '^version = "[0-9]+\.[0-9]+\.[0-9]+"' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
 if [ "$current_cargo_version" != "$version" ]; then
@@ -57,14 +62,9 @@ if [ "$current_cargo_version" != "$version" ]; then
     sed -i "s/^version = \"$current_cargo_version\"/version = \"$version\"/" Cargo.toml
 fi
 
-# Update dependency versions in README.md
-current_readme_version=$(grep -E 'maxminddb = "[0-9]+\.[0-9]+"' README.md | head -1 | sed 's/.*"\([0-9]\+\.[0-9]\+\)"/\1/')
-if [ "$current_readme_version" != "$readme_version" ]; then
-    echo "Updating README.md version from $current_readme_version to $readme_version"
-    sed -i -E \
-        "s/maxminddb = \"${current_readme_version}\"/maxminddb = \"${readme_version}\"/g; s/version = \"${current_readme_version}\"/version = \"${readme_version}\"/g" \
-        README.md
-fi
+# Update every dependency example and verify none were missed.
+echo "Updating README.md dependency versions to $readme_version"
+update_readme_dependency_versions README.md "$readme_version"
 
 echo "Running tests..."
 cargo test
@@ -79,13 +79,13 @@ read -r -p "Commit changes and push to origin? [y/N] " should_push
 
 if [ "$should_push" != "y" ]; then
     echo "Aborting"
-    git checkout -- Cargo.toml README.md
     exit 1
 fi
 
 if [ -n "$(git status --porcelain)" ]; then
     git commit -m "Prepare $tag release" -a
 fi
+trap - EXIT
 
 git push
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -12,10 +12,12 @@ use serde::de::{
     Visitor,
 };
 use serde::forward_to_deserialize_any;
-use std::collections::HashSet;
 use std::convert::TryInto;
 
 use crate::error::MaxMindDbError;
+
+mod verification;
+pub(crate) use verification::VerificationState;
 
 // MaxMind DB type constants
 const TYPE_EXTENDED: usize = 0;
@@ -181,13 +183,6 @@ pub(crate) struct Decoder<'de> {
     current_ptr: usize,
     state: u32,
     payload_remaining: u32,
-}
-
-/// Tracks data values visited by a single database verification pass.
-#[derive(Debug, Default)]
-pub(crate) struct VerificationState {
-    validated: HashSet<usize>,
-    active: HashSet<usize>,
 }
 
 impl<'de> Decoder<'de> {
@@ -1064,9 +1059,13 @@ impl<'de> Decoder<'de> {
         skip_depth: u16,
         state: &mut VerificationState,
     ) -> DecodeResult<()> {
+        // Charge every visited value, including inline children and pointers
+        // to cached targets, before traversal. Headers take constant work.
+        state.charge(1, self.current_ptr)?;
         match type_num {
             TYPE_STRING => {
                 let end = self.checked_offset(size, "string")?;
+                state.charge(size, self.current_ptr)?;
                 let bytes = self.slice(self.current_ptr, end);
                 self.current_ptr = end;
                 std::str::from_utf8(bytes)
@@ -2176,7 +2175,7 @@ mod tests {
     fn test_skip_value_for_verification_rejects_truncated_pointer_payload() {
         let mut decoder = Decoder::new(&[0x28], 0);
         let err = decoder
-            .skip_value_for_verification(&mut VerificationState::default())
+            .skip_value_for_verification(&mut VerificationState::new(decoder.limit))
             .unwrap_err();
 
         assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
@@ -2221,7 +2220,7 @@ mod tests {
 
             let mut decoder = Decoder::new(&encoded, 0);
             let err = decoder
-                .skip_value_for_verification(&mut VerificationState::default())
+                .skip_value_for_verification(&mut VerificationState::new(decoder.limit))
                 .unwrap_err();
             assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
 
@@ -2733,11 +2732,85 @@ mod tests {
     }
 
     #[test]
+    fn verification_bounds_overlapping_string_scans() {
+        // Each header is also valid ASCII inside preceding string payloads.
+        // Distinct target offsets defeat the exact-target cache.
+        let size = 65_821 + 65_536;
+        let mut buf = [0x5f, 0x01, 0x00, 0x00].repeat(64);
+        buf.resize(buf.len() + size, b'a');
+        let mut state = VerificationState::new(buf.len());
+        let allowance = state.work_remaining;
+        for index in 0..8 {
+            Decoder::new(&buf, index * 4)
+                .skip_value_for_verification(&mut state)
+                .unwrap();
+        }
+        assert_eq!(state.work_remaining, allowance - 8 * (size + 1));
+
+        let mut decoder = Decoder::new(&buf, 8 * 4);
+        let err = decoder.skip_value_for_verification(&mut state).unwrap_err();
+        assert!(matches!(
+            err,
+            MaxMindDbError::ResourceLimit {
+                offset: Some(36),
+                ..
+            }
+        ));
+        // The rejected string was neither scanned nor cached; only its visit
+        // was charged, and its cursor still points to the start of the payload.
+        assert_eq!(state.work_remaining, allowance - 8 * (size + 1) - 1);
+        assert_eq!(decoder.offset(), 36);
+        assert_eq!(state.validated.len(), 8);
+        assert!(state.active.is_empty());
+    }
+
+    #[test]
+    fn verification_bounds_repeated_inline_traversal_across_roots() {
+        let mut buf = [0x01, 0x04].repeat(64); // nested one-element arrays
+        buf.extend_from_slice(&[0x00, 0x07]); // false
+        let mut state = VerificationState::new(buf.len());
+        // Successive roots start inside earlier arrays. Inline children aren't
+        // cached, so even without string scans their repeated visits need a cap.
+        let err = (0..64)
+            .try_for_each(|index| {
+                Decoder::new(&buf, index * 2).skip_value_for_verification(&mut state)
+            })
+            .unwrap_err();
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert_eq!(state.work_remaining, 0);
+        assert!(state.active.is_empty());
+    }
+
+    #[test]
+    fn verification_allows_large_nonoverlapping_payloads() {
+        let size = super::MAXIMUM_DATA_STRUCTURE_BYTES + 1;
+        let mut buf = vec![0x5f];
+        buf.extend_from_slice(&((size - 65_821) as u32).to_be_bytes()[1..]);
+        buf.resize(buf.len() + size, b'a');
+        let mut state = VerificationState::new(buf.len());
+        Decoder::new(&buf, 0)
+            .skip_value_for_verification(&mut state)
+            .unwrap();
+    }
+
+    #[test]
+    fn verification_work_allowance_does_not_overflow() {
+        let mut state = VerificationState::new(usize::MAX);
+        assert_eq!(state.work_remaining, usize::MAX);
+        state.charge(usize::MAX, 0).unwrap();
+        assert!(matches!(
+            state.charge(1, 0),
+            Err(MaxMindDbError::ResourceLimit { .. })
+        ));
+        assert_eq!(state.work_remaining, 0);
+    }
+
+    #[test]
     fn test_verification_rejects_invalid_bool_size() {
         // Extended bool type with an invalid size value of two.
         let mut decoder = Decoder::new(&[0x02, 0x07], 0);
         let err = decoder
-            .skip_value_for_verification(&mut VerificationState::default())
+            .skip_value_for_verification(&mut VerificationState::new(decoder.limit))
             .unwrap_err();
 
         assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
@@ -2746,7 +2819,7 @@ mod tests {
     #[test]
     fn test_verification_rejects_and_does_not_cache_invalid_utf8() {
         let buf = [0x41, 0xff];
-        let mut state = VerificationState::default();
+        let mut state = VerificationState::new(buf.len());
 
         for _ in 0..2 {
             let mut decoder = Decoder::new(&buf, 0);
@@ -2790,7 +2863,7 @@ mod tests {
         }
 
         let mut decoder = Decoder::new(&buf, target);
-        let mut state = VerificationState::default();
+        let mut state = VerificationState::new(buf.len());
         decoder.skip_value_for_verification(&mut state).unwrap();
 
         assert_eq!(state.validated.len(), LEVELS + 1);
@@ -2807,7 +2880,7 @@ mod tests {
 
         let mut decoder = Decoder::new(&buf, 0);
         let err = decoder
-            .skip_value_for_verification(&mut VerificationState::default())
+            .skip_value_for_verification(&mut VerificationState::new(decoder.limit))
             .unwrap_err();
 
         assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -39,6 +39,35 @@ const RAW_STRINGS_NEWTYPE: &str = "$maxminddb::raw_strings";
 /// This matches the value used in libmaxminddb and the Go reader.
 const MAXIMUM_DATA_STRUCTURE_DEPTH: u16 = 512;
 
+/// Maximum number of logical values decoded in one container-shaped operation.
+/// A container reserves all of its children before the visitor enters it, so a
+/// pointer fan-out exhausts the budget without a counter update on every scalar
+/// header. A pointer and the value it resolves to are one logical occurrence.
+const MAXIMUM_DATA_STRUCTURE_VALUES: u32 = 1 << 16;
+
+/// Maximum total string and bytes payload delivered through budgeted decode
+/// paths. Re-decoding a shared target recharges its payload. Payload reached
+/// only through `skip_value`, including an unknown or `IgnoredAny` value, is not
+/// materialized or charged. Keys exposed to a dynamically shaped map visitor
+/// are conservatively precharged before the visitor's key seed runs, even when
+/// that seed ignores them.
+const MAXIMUM_DATA_STRUCTURE_BYTES: usize = 2 << 20;
+
+/// Identifier bytes covered by the logical-value budget rather than the
+/// payload counter. At most one identifier occurs per reserved logical value,
+/// so this allowance can add no more than another 2 MiB per operation while
+/// keeping ordinary short schema keys off the payload-accounting hot path.
+const MAXIMUM_UNCHARGED_IDENTIFIER_BYTES: usize =
+    MAXIMUM_DATA_STRUCTURE_BYTES / MAXIMUM_DATA_STRUCTURE_VALUES as usize;
+
+// Depth, the logical-value count, and the budget flags share one word,
+// preserving Decoder's existing size on 64-bit targets. Keeping the payload
+// allowance separate avoids extracting and replacing it for every string.
+const DEPTH_MASK: u32 = (1 << 10) - 1;
+const BUDGET_VALUES_SHIFT: u32 = 10;
+const BUDGET_VALUES_MASK: u32 = ((1 << 17) - 1) << BUDGET_VALUES_SHIFT;
+const BUDGET_ACTIVE_MASK: u32 = 1 << 27;
+
 /// Lower limit for values skipped through unknown fields or IgnoredAny.
 /// Skipping is recursive and can be reached by corrupt data that callers did
 /// not explicitly request, so keep the limit below small default thread stacks.
@@ -90,6 +119,21 @@ macro_rules! deserialize_direct_scalar {
     };
 }
 
+macro_rules! deserialize_direct_payload {
+    ($name:ident, $expected_type:expr, $label:literal, $visit:ident, $decode:ident) => {
+        fn $name<V>(self, visitor: V) -> DecodeResult<V::Value>
+        where
+            V: Visitor<'de>,
+        {
+            let (size, type_num) = self.size_and_type()?;
+            self.decode_direct(size, type_num, $expected_type, $label, |de, size| {
+                de.count_payload(size)?;
+                visitor.$visit(de.$decode(size)?)
+            })
+        }
+    };
+}
+
 enum Value<'a, 'de> {
     Any { prev_ptr: usize },
     Bytes(&'de [u8]),
@@ -103,7 +147,7 @@ enum Value<'a, 'de> {
     U128(u128),
     F64(f64),
     F32(f32),
-    Map(MapAccessor<'a, 'de>),
+    Map(MapAccessor<'a, 'de, true>),
     Array(ArrayAccess<'a, 'de>),
 }
 
@@ -116,7 +160,8 @@ pub(crate) struct Decoder<'de> {
     buf: &'de [u8],
     limit: usize,
     current_ptr: usize,
-    depth: u16,
+    state: u32,
+    payload_remaining: u32,
 }
 
 /// Tracks data values visited by a single database verification pass.
@@ -137,26 +182,132 @@ impl<'de> Decoder<'de> {
             buf,
             limit,
             current_ptr: start_ptr,
-            depth: 0,
+            state: 0,
+            payload_remaining: MAXIMUM_DATA_STRUCTURE_BYTES as u32,
+        }
+    }
+
+    #[inline(always)]
+    fn activate_budget(&mut self) {
+        if self.state & BUDGET_ACTIVE_MASK == 0 {
+            // The value that caused activation is the top-level budgeted value.
+            self.state |= BUDGET_ACTIVE_MASK | (1 << BUDGET_VALUES_SHIFT);
         }
     }
 
     /// Check and increment depth, returning error if limit exceeded.
     #[inline]
     fn enter_nested(&mut self) -> DecodeResult<()> {
-        if self.depth >= MAXIMUM_DATA_STRUCTURE_DEPTH {
+        if self.state & DEPTH_MASK >= u32::from(MAXIMUM_DATA_STRUCTURE_DEPTH) {
             return Err(self.invalid_db_error(
                 "exceeded maximum data structure depth; database is likely corrupt",
             ));
         }
-        self.depth += 1;
+        self.state += 1;
         Ok(())
     }
 
     /// Decrement depth when exiting a nested structure.
     #[inline]
     fn exit_nested(&mut self) {
-        self.depth = self.depth.saturating_sub(1);
+        if self.state & DEPTH_MASK != 0 {
+            self.state -= 1;
+        }
+    }
+
+    /// Reserve logical child values before entering a container. Charging the
+    /// complete child count up front bounds both flat containers and pointer
+    /// fan-out without touching the scalar decode hot path.
+    #[inline(always)]
+    fn reserve_values(&mut self, count: usize) -> DecodeResult<()> {
+        if self.state & BUDGET_ACTIVE_MASK == 0 {
+            return Ok(());
+        }
+        let values_used = ((self.state & BUDGET_VALUES_MASK) >> BUDGET_VALUES_SHIFT) as usize;
+        if count > MAXIMUM_DATA_STRUCTURE_VALUES as usize - values_used {
+            return Err(
+                self.resource_limit_error("exceeded maximum number of data structure values")
+            );
+        }
+        self.state += (count as u32) << BUDGET_VALUES_SHIFT;
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn reserve_container_values(&mut self, size: usize, type_num: usize) -> DecodeResult<()> {
+        // A scalar decoded on its own cannot fan out. The first map or array is
+        // the point at which one encoded value can produce unbounded work, so
+        // activate the shared operation budget here for every Serde shape.
+        self.activate_budget();
+        let count = if type_num == TYPE_MAP {
+            size.saturating_mul(2)
+        } else {
+            debug_assert_eq!(type_num, TYPE_ARRAY);
+            size
+        };
+        self.reserve_values(count)
+    }
+
+    /// Charge a string or bytes payload against the per-decode byte budget,
+    /// returning an error once the total exceeds the limit. This bounds a
+    /// payload amplification: many pointers to one large value each recharge the
+    /// budget, so the decoder will not repeatedly deliver more payload than the
+    /// limit no matter how heavily a target is shared. A custom visitor may
+    /// still allocate a representation larger than the borrowed input. Small
+    /// fixed-width scalars are not charged.
+    #[inline(always)]
+    fn count_payload(&mut self, size: usize) -> DecodeResult<()> {
+        if self.state & BUDGET_ACTIVE_MASK == 0 {
+            return Ok(());
+        }
+        if size > self.payload_remaining as usize {
+            return Err(self.resource_limit_error(
+                "exceeded maximum size of data structure string and bytes values",
+            ));
+        }
+        self.payload_remaining -= size as u32;
+        Ok(())
+    }
+
+    /// Charge identifier payload beyond the portion already covered by the
+    /// logical-value budget. Ordinary short schema keys remain free from
+    /// payload-counter updates.
+    #[inline(always)]
+    fn count_identifier_payload(&mut self, size: usize) -> DecodeResult<()> {
+        if size <= MAXIMUM_UNCHARGED_IDENTIFIER_BYTES {
+            return Ok(());
+        }
+        self.count_long_identifier_payload(size)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn count_long_identifier_payload(&mut self, size: usize) -> DecodeResult<()> {
+        self.count_payload(size - MAXIMUM_UNCHARGED_IDENTIFIER_BYTES)
+    }
+
+    /// Charges a string or bytes value at the current position without
+    /// consuming it. Dynamically shaped maps use this for keys because a raw
+    /// identifier visitor may copy them without requesting a string decode.
+    fn count_payload_at_current(&mut self) -> DecodeResult<bool> {
+        let saved_ptr = self.current_ptr;
+        let result = (|| {
+            let (mut size, mut type_num) = self.size_and_type()?;
+            if type_num == TYPE_POINTER {
+                self.current_ptr = self.decode_pointer(size);
+                (size, type_num) = self.size_and_type()?;
+                if type_num == TYPE_POINTER {
+                    return Err(self.invalid_db_error("pointer points to another pointer"));
+                }
+            }
+            if type_num == TYPE_STRING || type_num == TYPE_BYTES {
+                self.count_payload(size)?;
+                return Ok(true);
+            }
+            Ok(false)
+        })();
+        self.current_ptr = saved_ptr;
+        result
     }
 
     /// Create an InvalidDatabase error with current offset context.
@@ -169,6 +320,13 @@ impl<'de> Decoder<'de> {
     #[inline]
     fn decode_error(&self, msg: &str) -> MaxMindDbError {
         MaxMindDbError::decoding_at(msg, self.current_ptr)
+    }
+
+    /// Create a ResourceLimit error with current offset context.
+    #[cold]
+    #[inline(never)]
+    fn resource_limit_error(&self, msg: &str) -> MaxMindDbError {
+        MaxMindDbError::resource_limit_at(msg, self.current_ptr)
     }
 
     #[inline(always)]
@@ -261,11 +419,12 @@ impl<'de> Decoder<'de> {
             // Widen before adding so malformed bytes cannot overflow.
             type_num = usize::from(self.eat_byte()?) + TYPE_MAP;
         }
-        let size = self.size_from_ctrl_byte(ctrl_byte, type_num)?;
-        Ok((size, type_num))
+        self.size_from_ctrl_byte(ctrl_byte, type_num)
+            .map(|size| (size, type_num))
     }
 
     fn decode_any<V: Visitor<'de>>(&mut self, visitor: V) -> DecodeResult<V::Value> {
+        self.activate_budget();
         self.decode_any_impl::<false, V>(visitor)
     }
 
@@ -321,6 +480,7 @@ impl<'de> Decoder<'de> {
                 )));
             }
 
+            de.reserve_container_values(size, TYPE_ARRAY)?;
             de.enter_nested()?;
             let res = visitor.visit_seq(ArrayAccess { de, count: size });
             de.exit_nested();
@@ -340,13 +500,23 @@ impl<'de> Decoder<'de> {
 
                 Value::Any { prev_ptr }
             }
-            TYPE_STRING if RAW_STRINGS => Value::RawString(self.read_string_bytes(size)?),
-            TYPE_STRING => Value::String(self.decode_string(size)?),
+            TYPE_STRING if RAW_STRINGS => {
+                self.count_payload(size)?;
+                Value::RawString(self.read_string_bytes(size)?)
+            }
+            TYPE_STRING => {
+                self.count_payload(size)?;
+                Value::String(self.decode_string(size)?)
+            }
             TYPE_DOUBLE => Value::F64(self.decode_double(size)?),
-            TYPE_BYTES => Value::Bytes(self.decode_bytes(size)?),
+            TYPE_BYTES => {
+                self.count_payload(size)?;
+                Value::Bytes(self.decode_bytes(size)?)
+            }
             TYPE_UINT16 => Value::U16(self.decode_uint16(size)?),
             TYPE_UINT32 => Value::U32(self.decode_uint32(size)?),
             TYPE_MAP => {
+                self.reserve_container_values(size, TYPE_MAP)?;
                 self.enter_nested()?;
                 self.decode_map(size)
             }
@@ -354,6 +524,7 @@ impl<'de> Decoder<'de> {
             TYPE_UINT64 => Value::U64(self.decode_uint64(size)?),
             TYPE_UINT128 => Value::U128(self.decode_uint128(size)?),
             TYPE_ARRAY => {
+                self.reserve_container_values(size, TYPE_ARRAY)?;
                 self.enter_nested()?;
                 self.decode_array(size)
             }
@@ -557,7 +728,11 @@ impl<'de> Decoder<'de> {
 
     /// Consumes a map or array header in one pass, following a pointer if needed.
     pub(crate) fn consume_container_header(&mut self) -> DecodeResult<(usize, usize)> {
-        self.size_and_type_following_pointers()
+        let (size, type_num) = self.size_and_type_following_pointers()?;
+        if type_num == TYPE_MAP || type_num == TYPE_ARRAY {
+            self.reserve_container_values(size, type_num)?;
+        }
+        Ok((size, type_num))
     }
 
     /// Gets size and type, following any pointers.
@@ -640,14 +815,18 @@ impl<'de> Decoder<'de> {
                 let result = if type_num == TYPE_POINTER {
                     Err(self.invalid_db_error("pointer points to another pointer"))
                 } else if type_num == TYPE_STRING {
-                    self.read_string_bytes(size)
+                    self.count_payload(size)
+                        .and_then(|()| self.read_string_bytes(size))
                 } else {
                     Err(self.invalid_db_error(&format!("expected string, got type {type_num}")))
                 };
                 self.current_ptr = saved_ptr;
                 result
             }
-            TYPE_STRING => self.read_string_bytes(size),
+            TYPE_STRING => {
+                self.count_payload(size)?;
+                self.read_string_bytes(size)
+            }
             _ => Err(self.invalid_db_error(&format!("expected string, got type {type_num}"))),
         }
     }
@@ -656,11 +835,15 @@ impl<'de> Decoder<'de> {
     /// - Returns `Ok(Some(bytes))` and consumes the identifier when it is a string.
     /// - Returns `Ok(None)` and restores `current_ptr` when the next value is not a string.
     /// - Returns `Err` for malformed pointer chains or invalid string lengths.
+    #[inline(always)]
     fn try_read_identifier_bytes(&mut self) -> DecodeResult<Option<&'de [u8]>> {
         let saved_ptr = self.current_ptr;
         let (size, type_num) = self.size_and_type()?;
         match type_num {
-            TYPE_STRING => self.read_string_bytes(size).map(Some),
+            TYPE_STRING => {
+                self.count_identifier_payload(size)?;
+                self.read_string_bytes(size).map(Some)
+            }
             TYPE_POINTER => {
                 let new_ptr = self.decode_pointer(size);
                 let after_pointer = self.current_ptr;
@@ -669,7 +852,11 @@ impl<'de> Decoder<'de> {
                 let result = if inner_type == TYPE_POINTER {
                     Err(self.invalid_db_error("pointer points to another pointer"))
                 } else if inner_type == TYPE_STRING {
-                    self.read_string_bytes(inner_size).map(Some)
+                    let payload_result = self.count_identifier_payload(inner_size);
+                    match payload_result {
+                        Ok(()) => self.read_string_bytes(inner_size).map(Some),
+                        Err(error) => Err(error),
+                    }
                 } else {
                     Ok(None)
                 };
@@ -692,7 +879,7 @@ impl<'de> Decoder<'de> {
         }
     }
 
-    /// Skips the current value, following pointers.
+    /// Skips the current encoded value without expanding pointer targets.
     pub(crate) fn skip_value(&mut self) -> DecodeResult<()> {
         let (size, type_num) = self.size_and_type()?;
         self.skip_value_inner(size, type_num, 0)
@@ -760,15 +947,14 @@ impl<'de> Decoder<'de> {
         // cursor remains within the decoder limit.
         match type_num {
             TYPE_POINTER => {
-                let new_ptr = self.decode_pointer(size);
-                let saved_ptr = self.current_ptr;
-                self.current_ptr = new_ptr;
-                let result = match self.check_skip_depth(skip_depth) {
-                    Ok(child_depth) => self.skip_value_with_depth(child_depth),
-                    Err(err) => Err(err),
-                };
-                self.current_ptr = saved_ptr;
-                result
+                // The pointer token is the complete skipped value. Its target
+                // is not materialized, so following it would only amplify work
+                // the destination did not request. Full database verification
+                // still validates referenced targets.
+                let pointer_size = ((size >> 3) & 0x3) + 1;
+                self.checked_offset(pointer_size, "pointer")?;
+                self.decode_pointer(size);
+                Ok(())
             }
             TYPE_STRING | TYPE_BYTES => {
                 // String or Bytes - skip size bytes
@@ -821,6 +1007,7 @@ impl<'de> Decoder<'de> {
             }
             TYPE_MAP => {
                 // Map - skip size key-value pairs
+                self.reserve_container_values(size, TYPE_MAP)?;
                 let child_depth = self.check_skip_depth(skip_depth)?;
                 for _ in 0..size {
                     // key
@@ -832,6 +1019,7 @@ impl<'de> Decoder<'de> {
             }
             TYPE_ARRAY => {
                 // Array - skip size elements
+                self.reserve_container_values(size, TYPE_ARRAY)?;
                 let child_depth = self.check_skip_depth(skip_depth)?;
                 for _ in 0..size {
                     self.skip_value_with_depth(child_depth)?;
@@ -941,7 +1129,8 @@ pub type DecodeResult<T> = Result<T, MaxMindDbError>;
 /// [`Deserializer::deserialize_bytes`] is the conventional choice. Genuine
 /// MMDB byte values continue to be delivered directly to
 /// [`Visitor::visit_borrowed_bytes`], so callers can distinguish the two
-/// types.
+/// types. Values decoded through this helper share the operation's expansion
+/// budget.
 ///
 /// Callers decoding nested maps or arrays should invoke this helper again from
 /// the [`DeserializeSeed`] used for each nested value. Map keys can be read as
@@ -1037,7 +1226,7 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
         decode_double
     );
 
-    deserialize_direct_scalar!(
+    deserialize_direct_payload!(
         deserialize_str,
         TYPE_STRING,
         "string",
@@ -1052,7 +1241,7 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
         self.deserialize_str(visitor)
     }
 
-    deserialize_direct_scalar!(
+    deserialize_direct_payload!(
         deserialize_bytes,
         TYPE_BYTES,
         "bytes",
@@ -1073,6 +1262,7 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
     {
         let (size, type_num) = self.size_and_type()?;
         self.decode_direct(size, type_num, TYPE_ARRAY, "array", |de, size| {
+            de.reserve_container_values(size, TYPE_ARRAY)?;
             de.enter_nested()?;
             let res = visitor.visit_seq(ArrayAccess { de, count: size });
             de.exit_nested();
@@ -1103,16 +1293,7 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
     where
         V: Visitor<'de>,
     {
-        let (size, type_num) = self.size_and_type()?;
-        self.decode_direct(size, type_num, TYPE_MAP, "map", |de, size| {
-            de.enter_nested()?;
-            let res = visitor.visit_map(MapAccessor {
-                de,
-                count: size * 2,
-            });
-            de.exit_nested();
-            res
-        })
+        self.deserialize_map_impl(visitor)
     }
 
     fn deserialize_struct<V>(
@@ -1124,7 +1305,7 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
     where
         V: Visitor<'de>,
     {
-        self.deserialize_map(visitor)
+        self.deserialize_map_impl(visitor)
     }
 
     fn is_human_readable(&self) -> bool {
@@ -1148,6 +1329,7 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
     where
         V: Visitor<'de>,
     {
+        self.activate_budget();
         visitor.visit_enum(EnumAccessor { de: self })
     }
 
@@ -1166,6 +1348,7 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
         V: Visitor<'de>,
     {
         if name == RAW_STRINGS_NEWTYPE {
+            self.activate_budget();
             self.decode_any_impl::<true, V>(visitor)
         } else {
             self.decode_any(visitor)
@@ -1174,6 +1357,25 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
 
     forward_to_deserialize_any! {
         i8 i16 i64 i128 u8 char unit unit_struct
+    }
+}
+
+impl<'de> Decoder<'de> {
+    fn deserialize_map_impl<V>(&mut self, visitor: V) -> DecodeResult<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        let (size, type_num) = self.size_and_type()?;
+        self.decode_direct(size, type_num, TYPE_MAP, "map", |de, size| {
+            de.reserve_container_values(size, TYPE_MAP)?;
+            de.enter_nested()?;
+            let res = visitor.visit_map(MapAccessor::<false> {
+                de,
+                count: size * 2,
+            });
+            de.exit_nested();
+            res
+        })
     }
 }
 
@@ -1216,14 +1418,14 @@ impl<'de> SeqAccess<'de> for ArrayAccess<'_, 'de> {
     }
 }
 
-struct MapAccessor<'a, 'de: 'a> {
+struct MapAccessor<'a, 'de: 'a, const BUDGETED: bool = false> {
     de: &'a mut Decoder<'de>,
     count: usize,
 }
 
 // `MapAccess` is provided to the `Visitor` to give it the ability to iterate
 // through entries of the map.
-impl<'de> MapAccess<'de> for MapAccessor<'_, 'de> {
+impl<'de, const BUDGETED: bool> MapAccess<'de> for MapAccessor<'_, 'de, BUDGETED> {
     type Error = MaxMindDbError;
 
     #[inline(always)]
@@ -1248,6 +1450,23 @@ impl<'de> MapAccess<'de> for MapAccessor<'_, 'de> {
             return Ok(None);
         }
         self.count -= 1;
+
+        if BUDGETED {
+            let payload_remaining_before = self.de.payload_remaining;
+            let payload_precharged = self.de.count_payload_at_current()?;
+            let payload_remaining_after = self.de.payload_remaining;
+
+            // Let the seed perform its ordinary payload charge, while retaining
+            // the precharge if an identifier visitor does not request one. This
+            // avoids disabling a budget that deserialize_any can reactivate and
+            // keeps the ordinary payload counter free of a map-key-only branch.
+            self.de.payload_remaining = payload_remaining_before;
+            let result = seed.deserialize(&mut *self.de).map(Some);
+            if payload_precharged {
+                self.de.payload_remaining = self.de.payload_remaining.min(payload_remaining_after);
+            }
+            return result;
+        }
 
         // Deserialize a map key.
         seed.deserialize(&mut *self.de).map(Some)
@@ -1297,7 +1516,11 @@ impl<'de> de::VariantAccess<'de> for EnumAccessor<'_, 'de> {
     where
         T: DeserializeSeed<'de>,
     {
-        seed.deserialize(&mut *self.de)
+        self.de.reserve_values(1)?;
+        self.de.enter_nested()?;
+        let result = seed.deserialize(&mut *self.de);
+        self.de.exit_nested();
+        result
     }
 
     fn tuple_variant<V>(self, len: usize, visitor: V) -> DecodeResult<V::Value>
@@ -1482,6 +1705,94 @@ mod tests {
 
         fn visit_borrowed_bytes<E>(self, bytes: &'de [u8]) -> Result<Self::Value, E> {
             Ok(bytes.to_vec())
+        }
+    }
+
+    struct AnyIdentifierSeed;
+
+    impl<'de> DeserializeSeed<'de> for AnyIdentifierSeed {
+        type Value = usize;
+
+        fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_any(AnyIdentifierVisitor)
+        }
+    }
+
+    struct AnyIdentifierVisitor;
+
+    impl<'de> Visitor<'de> for AnyIdentifierVisitor {
+        type Value = usize;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("an MMDB map key")
+        }
+
+        fn visit_borrowed_str<E>(self, value: &'de str) -> Result<Self::Value, E> {
+            Ok(value.len())
+        }
+
+        fn visit_borrowed_bytes<E>(self, value: &'de [u8]) -> Result<Self::Value, E> {
+            Ok(value.len())
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct AnyKeyMap(usize);
+
+    struct AnyKeyMapVisitor;
+
+    impl<'de> Visitor<'de> for AnyKeyMapVisitor {
+        type Value = AnyKeyMap;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("an MMDB map")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            let mut count = 0;
+            while let Some(key_size) = map.next_key_seed(AnyIdentifierSeed)? {
+                assert_eq!(key_size, 4096);
+                map.next_value::<serde::de::IgnoredAny>()?;
+                count += 1;
+            }
+            Ok(AnyKeyMap(count))
+        }
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct OwnedBytes(Vec<u8>);
+
+    impl<'de> Deserialize<'de> for OwnedBytes {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_byte_buf(OwnedBytesVisitor)
+        }
+    }
+
+    struct OwnedBytesVisitor;
+
+    impl<'de> Visitor<'de> for OwnedBytesVisitor {
+        type Value = OwnedBytes;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("an MMDB byte value")
+        }
+
+        fn visit_borrowed_bytes<E>(self, value: &'de [u8]) -> Result<Self::Value, E> {
+            Ok(OwnedBytes(value.to_vec()))
+        }
+
+        fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Self::Value, E> {
+            Ok(OwnedBytes(value))
         }
     }
 
@@ -1851,6 +2162,44 @@ mod tests {
     }
 
     #[test]
+    fn ignored_any_skips_pointer_targets_but_verification_follows_them() {
+        for (pointer_size, control) in [(1, 0x20), (2, 0x28), (3, 0x30), (4, 0x38)] {
+            // Each pointer targets a location outside this buffer. Skipping
+            // must resume at the next value without expanding that target.
+            let mut encoded = vec![control];
+            encoded.resize(pointer_size + 1, 0xff);
+            let continuation = encoded.len();
+            encoded.extend([0xa1, 42]); // uint16 with a one-byte payload
+            let mut decoder = Decoder::new(&encoded, 0);
+            serde::de::IgnoredAny::deserialize(&mut decoder).unwrap();
+            assert_eq!(decoder.offset(), continuation);
+            assert_eq!(u16::deserialize(&mut decoder).unwrap(), 42);
+            assert_eq!(decoder.offset(), encoded.len());
+
+            let mut decoder = Decoder::new(&encoded, 0);
+            let err = decoder
+                .skip_value_for_verification(&mut VerificationState::default())
+                .unwrap_err();
+            assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+
+            // Every truncated payload must fail without advancing beyond the
+            // header, even when bytes exist outside the decoder's limit.
+            for limit in 1..continuation {
+                for buf in [&encoded[..limit], &encoded[..]] {
+                    let mut decoder = Decoder::new_with_limit(buf, 0, limit);
+                    let err = serde::de::IgnoredAny::deserialize(&mut decoder).unwrap_err();
+                    assert!(matches!(
+                        err,
+                        MaxMindDbError::InvalidDatabase { message, offset: Some(1) }
+                            if message == format!("pointer of size {pointer_size}")
+                    ));
+                    assert_eq!(decoder.offset(), 1);
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_decoder_caps_impossible_container_size_hint() {
         // Extended array with 284 declared elements and no element payload.
         let mut decoder = Decoder::new(&[0x1d, 0x04, 0xff], 0);
@@ -1858,6 +2207,486 @@ mod tests {
 
         assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
         assert!(err.to_string().contains("unexpected end of buffer"));
+    }
+
+    #[test]
+    fn ignored_any_rejects_excessive_inline_container_work() {
+        // Extended array with 65,536 declared elements and no payload. An
+        // ignored inline container still requires one loop iteration per
+        // child, so it shares the logical-value operation budget.
+        let mut decoder = Decoder::new(&[0x1e, 0x04, 0xfe, 0xe3], 0);
+        let err = serde::de::IgnoredAny::deserialize(&mut decoder).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("maximum number of data structure values"));
+    }
+
+    #[test]
+    fn ignored_any_rejects_excessive_inline_map_work() {
+        // A 32,768-entry map contains 65,536 children in addition to the map
+        // itself, so it cannot fit within the logical-value operation budget.
+        let mut decoder = Decoder::new(&[0xfe, 0x7e, 0xe3], 0);
+        let err = serde::de::IgnoredAny::deserialize(&mut decoder).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum number of data structure values"));
+    }
+
+    #[test]
+    fn navigation_rejects_excessive_declared_container_work() {
+        let mut decoder = Decoder::new(&[0x1e, 0x04, 0xfe, 0xe3], 0);
+        let err = decoder.consume_container_header().unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("maximum number of data structure values"));
+    }
+
+    #[test]
+    fn oversized_containers_fail_before_visitor_entry() {
+        use std::cell::Cell;
+
+        struct EntryVisitor<'a>(&'a Cell<bool>);
+        impl<'de> Visitor<'de> for EntryVisitor<'_> {
+            type Value = ();
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a container")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, _: A) -> Result<(), A::Error> {
+                self.0.set(true);
+                Ok(())
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, _: A) -> Result<(), A::Error> {
+                self.0.set(true);
+                Ok(())
+            }
+        }
+
+        let mut array = vec![0x1e, 0x04, 0xfe, 0xe3]; // 65,536 elements
+        array.extend([0x00, 0x07].repeat(65_536)); // false
+        let mut map = vec![0xfe, 0x7e, 0xe3]; // 32,768 entries
+        map.extend([0x40, 0x00, 0x07].repeat(32_768)); // empty string => false
+
+        // Complete payloads leave room for a large size hint. Neither concrete
+        // nor dynamic entry points may expose it to a visitor before rejecting.
+        for (is_map, bytes) in [(false, array), (true, map)] {
+            for dynamic in [false, true] {
+                let entered = Cell::new(false);
+                let mut decoder = Decoder::new(&bytes, 0);
+                let visitor = EntryVisitor(&entered);
+                let result = if dynamic {
+                    decoder.deserialize_any(visitor)
+                } else if is_map {
+                    decoder.deserialize_map(visitor)
+                } else {
+                    decoder.deserialize_seq(visitor)
+                };
+                assert!(matches!(result, Err(MaxMindDbError::ResourceLimit { .. })));
+                assert!(
+                    !entered.get(),
+                    "visitor entered: map={is_map}, dynamic={dynamic}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn city_subdivisions_reject_declared_size_before_allocating() {
+        // Extended array with 65,536 elements and no payload. Concrete Vec
+        // decoding must reject its declared children before Serde sees the
+        // size hint and can allocate for them.
+        let mut decoder = Decoder::new(&[0x1e, 0x04, 0xfe, 0xe3], 0);
+        let err =
+            Vec::<crate::geoip2::city::Subdivision<'_>>::deserialize(&mut decoder).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum number of data structure values"));
+    }
+
+    #[test]
+    fn concrete_map_rejects_declared_size_before_allocating() {
+        // Extended map with 32,768 entries and no payload. Map children include
+        // both keys and values, so this exceeds the 65,536-value operation
+        // budget once the top-level map itself is included. The rejection must
+        // happen before HashMap receives a size hint and can allocate.
+        let mut decoder = Decoder::new(&[0xfe, 0x7e, 0xe3], 0);
+        let err =
+            std::collections::HashMap::<String, serde::de::IgnoredAny>::deserialize(&mut decoder)
+                .unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum number of data structure values"));
+    }
+
+    #[test]
+    fn concrete_sequence_charges_repeated_shared_struct_maps() {
+        #[derive(Debug, Deserialize)]
+        struct EmptyRecord {}
+
+        // A shared 200-entry map followed by an array of 300 pointers to that
+        // map. Every map entry is unknown to EmptyRecord. Ignoring its value is
+        // cheap, but the requested struct still has to examine every key each
+        // time the pointer target is decoded. Aggregate container reservation
+        // rejects that fan-out after bounded work.
+        let mut buf = vec![0xfd, 171]; // map size: 29 + 171 = 200
+        for _ in 0..200 {
+            buf.extend_from_slice(&[0x40, 0xe0]); // empty string => empty map
+        }
+        let array_offset = buf.len();
+        buf.extend_from_slice(&[0x1e, 0x04, 0x00, 0x0f]); // array size: 300
+        for _ in 0..300 {
+            append_pointer(&mut buf, 0);
+        }
+
+        let mut decoder = Decoder::new(&buf, array_offset);
+        let err = Vec::<EmptyRecord>::deserialize(&mut decoder).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum number of data structure values"));
+    }
+
+    #[test]
+    fn concrete_sequence_charges_repeated_string_payloads() {
+        // One 4 KiB string followed by an array of 600 pointers to it. The
+        // array activates the operation budget, and direct &str decoding must
+        // recharge the shared payload for every logical occurrence.
+        let (buf, array_offset) = repeated_4k_payload_array(0x5e, 600);
+
+        let mut decoder = Decoder::new(&buf, array_offset);
+        let err = Vec::<&str>::deserialize(&mut decoder).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum size of data structure string and bytes"));
+    }
+
+    #[test]
+    fn direct_byte_buf_decoding_charges_repeated_payloads() {
+        let (buf, array_offset) = repeated_4k_payload_array(0x9e, 600);
+        let mut decoder = Decoder::new(&buf, array_offset);
+        let err = Vec::<OwnedBytes>::deserialize(&mut decoder).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum size of data structure string and bytes"));
+    }
+
+    #[test]
+    fn raw_string_decoding_charges_repeated_payloads() {
+        let (buf, array_offset) = repeated_4k_payload_array(0x5e, 600);
+        let mut decoder = Decoder::new(&buf, array_offset);
+        let err = RawValueSeed.deserialize(&mut decoder).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum size of data structure string and bytes"));
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    enum StandaloneScalarEnum {
+        Known,
+    }
+
+    fn large_string(size: usize) -> Vec<u8> {
+        assert!((65_821..=65_821 + 0xff_ff_ff).contains(&size));
+        let encoded_size = (size - 65_821) as u32;
+        let mut buf = vec![0x5f]; // string with a three-byte extended size
+        buf.extend_from_slice(&encoded_size.to_be_bytes()[1..]);
+        buf.resize(buf.len() + size, b'a');
+        buf
+    }
+
+    #[test]
+    fn partial_struct_skips_unknown_inline_payload_over_budget() {
+        #[derive(Deserialize)]
+        struct PartialRecord {
+            known: bool,
+        }
+
+        let payload_size = super::MAXIMUM_DATA_STRUCTURE_BYTES + 1;
+        for control in [0x5f, 0x9f] {
+            let mut payload = large_string(payload_size);
+            payload[0] = control; // string or bytes with a three-byte extended size
+
+            let mut buf = vec![0xe2, 0x47]; // two-entry map, seven-byte key
+            buf.extend_from_slice(b"unknown");
+            buf.extend_from_slice(&payload);
+            buf.extend_from_slice(&[0x45]); // five-byte key
+            buf.extend_from_slice(b"known");
+            buf.extend_from_slice(&[0x01, 0x07]); // true
+
+            let mut decoder = Decoder::new(&buf, 0);
+            let decoded = PartialRecord::deserialize(&mut decoder).unwrap();
+            assert!(decoded.known);
+        }
+    }
+
+    #[test]
+    fn budgeted_standalone_scalar_entry_points_enforce_payload_limit() {
+        // The enum identifier receives the 32-byte allowance, so exceed both
+        // that allowance and the ordinary 2 MiB payload budget by one byte.
+        let size =
+            super::MAXIMUM_DATA_STRUCTURE_BYTES + super::MAXIMUM_UNCHARGED_IDENTIFIER_BYTES + 1;
+        let buf = large_string(size);
+
+        let mut decoder = Decoder::new(&buf, 0);
+        let err = serde_json::Value::deserialize(&mut decoder).unwrap_err();
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+
+        let mut decoder = Decoder::new(&buf, 0);
+        let err = RawValueSeed.deserialize(&mut decoder).unwrap_err();
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+
+        let mut decoder = Decoder::new(&buf, 0);
+        let err = StandaloneScalarEnum::deserialize(&mut decoder).unwrap_err();
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+
+        // A directly requested typed scalar intentionally retains its
+        // unbudgeted fast path because one scalar cannot amplify through
+        // container or pointer fan-out.
+        let mut decoder = Decoder::new(&buf, 0);
+        let decoded = <&str>::deserialize(&mut decoder).unwrap();
+        assert_eq!(decoded.len(), size);
+    }
+
+    #[test]
+    fn standalone_scalar_retains_unbudgeted_fast_path() {
+        let size = super::MAXIMUM_DATA_STRUCTURE_BYTES + 1;
+        let buf = large_string(size);
+
+        let mut decoder = Decoder::new(&buf, 0);
+        let decoded = <&str>::deserialize(&mut decoder).unwrap();
+        assert_eq!(decoded.len(), size);
+    }
+
+    fn repeated_4k_payload_array(control: u8, element_count: usize) -> (Vec<u8>, usize) {
+        // A shared 4 KiB string or bytes value followed by an array of pointers
+        // to it. Both payload types use the same extended-size representation.
+        assert!(matches!(control, 0x5e | 0x9e));
+        let mut buf = vec![control, 0x0e, 0xe3]; // size: 285 + 3,811 = 4,096
+        buf.resize(buf.len() + 4096, b'a');
+        let array_offset = buf.len();
+
+        assert!((285..=u16::MAX as usize + 285).contains(&element_count));
+        buf.extend_from_slice(&[0x1e, 0x04]); // array with a two-byte extended size
+        buf.extend_from_slice(&((element_count - 285) as u16).to_be_bytes());
+        for _ in 0..element_count {
+            append_pointer(&mut buf, 0);
+        }
+
+        (buf, array_offset)
+    }
+
+    fn pointer_key_map(entry_count: usize) -> (Vec<u8>, usize) {
+        // A shared 4 KiB string followed by a map whose keys all point to it.
+        let mut buf = vec![0x5e, 0x0e, 0xe3]; // string size: 285 + 3,811 = 4,096
+        buf.resize(buf.len() + 4096, b'k');
+        let map_offset = buf.len();
+
+        assert!((285..=u16::MAX as usize + 285).contains(&entry_count));
+        buf.push(0xfe); // map with a two-byte extended size
+        buf.extend_from_slice(&((entry_count - 285) as u16).to_be_bytes());
+        for _ in 0..entry_count {
+            append_pointer(&mut buf, 0);
+            buf.extend_from_slice(&[0x00, 0x07]); // false
+        }
+
+        (buf, map_offset)
+    }
+
+    fn repeated_inline_key_map_array(element_count: usize) -> (Vec<u8>, usize) {
+        // A one-entry map with a 4 KiB inline key, followed by an array of
+        // pointers that repeatedly expands that map.
+        let mut buf = vec![0xe1, 0x5e, 0x0e, 0xe3]; // map(1), string(4,096)
+        buf.resize(buf.len() + 4096, b'k');
+        buf.extend_from_slice(&[0x00, 0x07]); // false
+        let array_offset = buf.len();
+
+        assert!((285..=u16::MAX as usize + 285).contains(&element_count));
+        buf.extend_from_slice(&[0x1e, 0x04]); // array with a two-byte extended size
+        buf.extend_from_slice(&((element_count - 285) as u16).to_be_bytes());
+        for _ in 0..element_count {
+            append_pointer(&mut buf, 0);
+        }
+
+        (buf, array_offset)
+    }
+
+    #[test]
+    fn dynamic_map_keys_are_charged_once() {
+        // 512 copies of a 4 KiB key exactly fill the 2 MiB payload budget.
+        // Dynamic maps precharge keys before invoking an identifier visitor;
+        // the visitor must not charge the same payload a second time.
+        let (buf, map_offset) = pointer_key_map(512);
+        let mut decoder = Decoder::new(&buf, map_offset);
+        let value = RawValueSeed.deserialize(&mut decoder).unwrap();
+
+        let RawValue::Map(entries) = value else {
+            panic!("expected map");
+        };
+        assert_eq!(entries.len(), 512);
+
+        // Raw identifiers have a small uncharged allowance. The full dynamic
+        // precharge must still reject the first key beyond the payload budget.
+        let (buf, map_offset) = pointer_key_map(513);
+        let mut decoder = Decoder::new(&buf, map_offset);
+        let err = RawValueSeed.deserialize(&mut decoder).unwrap_err();
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum size of data structure string and bytes"));
+    }
+
+    #[test]
+    fn dynamic_any_map_keys_are_charged_once() {
+        // deserialize_any activates the budget itself. The map accessor's
+        // precharge must still suppress exactly one payload charge rather than
+        // charging each 4 KiB key twice.
+        let (buf, map_offset) = pointer_key_map(512);
+        let mut decoder = Decoder::new(&buf, map_offset);
+        assert_eq!(
+            decoder.deserialize_any(AnyKeyMapVisitor).unwrap(),
+            AnyKeyMap(512)
+        );
+
+        // The precharge remains effective: one additional key exceeds 2 MiB.
+        let (buf, map_offset) = pointer_key_map(513);
+        let mut decoder = Decoder::new(&buf, map_offset);
+        let err = decoder.deserialize_any(AnyKeyMapVisitor).unwrap_err();
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum size of data structure string and bytes"));
+    }
+
+    #[test]
+    fn navigation_charges_repeated_pointer_keys() {
+        let (buf, map_offset) = pointer_key_map(513);
+        let mut decoder = Decoder::new(&buf, map_offset);
+        let (size, type_num) = decoder.consume_container_header().unwrap();
+        assert_eq!((size, type_num), (513, super::TYPE_MAP));
+
+        for _ in 0..512 {
+            assert_eq!(decoder.read_str_as_bytes().unwrap().len(), 4096);
+            decoder.skip_value().unwrap();
+        }
+        let err = decoder.read_str_as_bytes().unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("maximum size of data structure string and bytes"));
+    }
+
+    #[test]
+    fn flattened_pointer_keys_cannot_bypass_payload_budget() {
+        #[derive(Debug, Deserialize)]
+        struct Flattened {
+            #[serde(flatten)]
+            fields: std::collections::HashMap<String, serde::de::IgnoredAny>,
+        }
+
+        // Each key charges 4,096 - 32 = 4,064 bytes after the per-identifier
+        // allowance. 516 copies leave 128 bytes in the 2 MiB payload budget.
+        let (buf, map_offset) = pointer_key_map(516);
+        let mut decoder = Decoder::new(&buf, map_offset);
+        let decoded = Flattened::deserialize(&mut decoder).unwrap();
+        assert_eq!(decoded.fields.len(), 1);
+
+        // The 517th copy exceeds that budget. Serde buffers flattened keys, so
+        // concrete struct identifier decoding must charge long keys while
+        // ordinary short City keys stay on the uncharged fast path.
+        let (buf, map_offset) = pointer_key_map(517);
+        let mut decoder = Decoder::new(&buf, map_offset);
+        let err = Flattened::deserialize(&mut decoder).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum size of data structure string and bytes"));
+    }
+
+    #[test]
+    fn repeated_maps_with_inline_keys_cannot_bypass_payload_budget() {
+        #[derive(Debug, Deserialize)]
+        struct Flattened {
+            #[serde(flatten)]
+            fields: std::collections::HashMap<String, serde::de::IgnoredAny>,
+        }
+
+        // The inline path has the same exact boundary as pointer-backed keys.
+        let (buf, array_offset) = repeated_inline_key_map_array(516);
+        let mut decoder = Decoder::new(&buf, array_offset);
+        let decoded = Vec::<Flattened>::deserialize(&mut decoder).unwrap();
+        assert_eq!(decoded.len(), 516);
+        assert!(decoded.iter().all(|value| value.fields.len() == 1));
+
+        // One additional expansion exceeds the aggregate identifier budget.
+        let (buf, array_offset) = repeated_inline_key_map_array(517);
+        let mut decoder = Decoder::new(&buf, array_offset);
+        let err = Vec::<Flattened>::deserialize(&mut decoder).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(err
+            .to_string()
+            .contains("maximum size of data structure string and bytes"));
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    enum RecursiveEnum {
+        Next(Box<RecursiveEnum>),
+        End,
+    }
+
+    fn recursive_enum_chain(in_array: bool) -> (Vec<u8>, usize) {
+        let mut buf = vec![0x44, b'N', b'e', b'x', b't'];
+        let start = buf.len();
+        if in_array {
+            buf.extend_from_slice(&[0x01, 0x04]); // one-element array
+        }
+        for _ in 0..=super::MAXIMUM_DATA_STRUCTURE_DEPTH {
+            append_pointer(&mut buf, 0);
+        }
+        buf.extend_from_slice(&[0x43, b'E', b'n', b'd']);
+        (buf, start)
+    }
+
+    #[test]
+    fn recursive_newtype_enum_is_depth_bounded() {
+        let (buf, start) = recursive_enum_chain(false);
+        let mut decoder = Decoder::new(&buf, start);
+        let err = RecursiveEnum::deserialize(&mut decoder).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("exceeded maximum data structure depth"));
+    }
+
+    #[test]
+    fn recursive_newtype_enum_inside_array_is_depth_bounded() {
+        let (buf, start) = recursive_enum_chain(true);
+        let mut decoder = Decoder::new(&buf, start);
+        let err = Vec::<RecursiveEnum>::deserialize(&mut decoder).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("exceeded maximum data structure depth"));
     }
 
     #[test]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -80,6 +80,25 @@ fn to_usize(base: u8, bytes: &[u8]) -> usize {
         .fold(base as usize, |acc, &b| (acc << 8) | b as usize)
 }
 
+#[cfg(not(feature = "unsafe-str-decode"))]
+#[inline]
+fn is_ascii(bytes: &[u8]) -> bool {
+    // Overlapping word reads cover short strings without a byte-by-byte tail.
+    match bytes.len() {
+        4..=7 => {
+            let first = u32::from_ne_bytes(bytes[..4].try_into().unwrap());
+            let last = u32::from_ne_bytes(bytes[bytes.len() - 4..].try_into().unwrap());
+            (first | last) & 0x8080_8080 == 0
+        }
+        8..=16 => {
+            let first = u64::from_ne_bytes(bytes[..8].try_into().unwrap());
+            let last = u64::from_ne_bytes(bytes[bytes.len() - 8..].try_into().unwrap());
+            (first | last) & 0x8080_8080_8080_8080 == 0
+        }
+        _ => bytes.is_ascii(),
+    }
+}
+
 macro_rules! decode_int_like {
     ($name:ident, $ty:ty, $max_size:expr, $label:literal, $zero:expr) => {
         fn $name(&mut self, size: usize) -> DecodeResult<$ty> {
@@ -677,6 +696,7 @@ impl<'de> Decoder<'de> {
     }
 
     #[cfg(feature = "unsafe-str-decode")]
+    #[inline(always)]
     fn decode_string(&mut self, size: usize) -> DecodeResult<&'de str> {
         use std::str::from_utf8_unchecked;
 
@@ -693,6 +713,7 @@ impl<'de> Decoder<'de> {
     }
 
     #[cfg(not(feature = "unsafe-str-decode"))]
+    #[inline(always)]
     fn decode_string(&mut self, size: usize) -> DecodeResult<&'de str> {
         #[cfg(feature = "simdutf8")]
         use simdutf8::basic::from_utf8;
@@ -703,7 +724,7 @@ impl<'de> Decoder<'de> {
         let new_offset = self.checked_offset(size, "string")?;
         let bytes = self.slice(self.current_ptr, new_offset);
         self.current_ptr = new_offset;
-        if bytes.is_ascii() {
+        if is_ascii(bytes) {
             // ASCII is valid UTF-8, so this avoids the full validator fast path.
             // SAFETY: `is_ascii()` guarantees UTF-8 validity.
             let v = unsafe { from_utf8_unchecked(bytes) };
@@ -2159,6 +2180,28 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+    }
+
+    #[cfg(not(feature = "unsafe-str-decode"))]
+    #[test]
+    fn ascii_check_covers_every_byte_at_word_boundaries() {
+        for len in 0..=80 {
+            let mut storage = vec![0x7f; len + 7];
+            for offset in 0..8 {
+                let bytes = &mut storage[offset..offset + len];
+                assert!(super::is_ascii(bytes));
+                for index in 0..len {
+                    for byte in 0x80..=0xff {
+                        bytes[index] = byte;
+                        assert!(
+                            !super::is_ascii(bytes),
+                            "accepted non-ASCII byte {byte} at index {index}, length {len}, offset {offset}"
+                        );
+                    }
+                    bytes[index] = 0x7f;
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/decoder/verification.rs
+++ b/src/decoder/verification.rs
@@ -1,0 +1,40 @@
+//! Shared-target caching and work accounting for database verification.
+//!
+//! Keeping these cold helpers separate and out of line limits verification
+//! bookkeeping's influence on the record decoder's generated code.
+
+use super::DecodeResult;
+use crate::MaxMindDbError;
+use std::collections::HashSet;
+
+/// Tracks data values visited by a single database verification pass.
+#[derive(Debug)]
+pub(crate) struct VerificationState {
+    pub(super) validated: HashSet<usize>,
+    pub(super) active: HashSet<usize>,
+    pub(super) work_remaining: usize,
+}
+
+impl VerificationState {
+    #[cold]
+    #[inline(never)]
+    pub(crate) fn new(section_size: usize) -> Self {
+        Self {
+            validated: HashSet::new(),
+            active: HashSet::new(),
+            // Allow ordinary inline and pointer-target visits with headroom,
+            // but bound repeated traversal and scans of overlapping payloads.
+            // Saturation keeps the allowance bounded even on 32-bit targets.
+            work_remaining: section_size.saturating_mul(8),
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    pub(super) fn charge(&mut self, amount: usize, offset: usize) -> DecodeResult<()> {
+        self.work_remaining = self.work_remaining.checked_sub(amount).ok_or_else(|| {
+            MaxMindDbError::resource_limit_at("exceeded maximum verification work", offset)
+        })?;
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,9 @@ pub enum MaxMindDbError {
     InvalidDatabase {
         /// Description of what is invalid.
         message: String,
-        /// Byte offset in the database where the error was detected.
+        /// Byte offset where the error was detected. Reader operations report
+        /// an absolute database-file offset; decoding a standalone section
+        /// reports an offset relative to that input.
         offset: Option<usize>,
     },
 
@@ -160,6 +162,22 @@ impl MaxMindDbError {
             message: message.into(),
             offset: Some(offset),
             path: None,
+        }
+    }
+
+    /// Translate a decoder-originated invalid-database offset from a section
+    /// into the containing database. Other error variants intentionally retain
+    /// their documented section-relative offsets.
+    pub(crate) fn with_invalid_database_offset_base(self, base: usize) -> Self {
+        match self {
+            MaxMindDbError::InvalidDatabase {
+                message,
+                offset: Some(offset),
+            } => MaxMindDbError::InvalidDatabase {
+                message,
+                offset: offset.checked_add(base),
+            },
+            _ => self,
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,13 +34,38 @@ pub enum MaxMindDbError {
     Mmap(#[source] io::Error),
 
     /// Error decoding data from the database.
-    #[error("{}", format_decoding_error(.message, .offset, .path.as_deref()))]
+    #[error(
+        "{}",
+        format_contextual_error("decoding error", .message, .offset, .path.as_deref())
+    )]
     Decoding {
         /// Description of the decoding error.
         message: String,
-        /// Byte offset in the data section where the error occurred.
+        /// Byte offset relative to the section being decoded: the data section
+        /// for records, or the metadata value after its marker for metadata.
         offset: Option<usize>,
         /// JSON-pointer-like path to the field (e.g., "/city/names/en").
+        path: Option<String>,
+    },
+
+    /// Decoding stopped because the requested value exceeded a decoder-wide
+    /// expansion safety limit.
+    ///
+    /// This does not necessarily mean that the database is structurally
+    /// invalid. Schema-specific limits reported by a custom Serde visitor use
+    /// [`MaxMindDbError::Decoding`] instead. Applications may choose a narrower
+    /// schema or reject the database as untrusted input.
+    #[error(
+        "{}",
+        format_contextual_error("resource limit exceeded", .message, .offset, .path.as_deref())
+    )]
+    ResourceLimit {
+        /// Description of the limit that was exceeded.
+        message: String,
+        /// Byte offset relative to the section being decoded: the data section
+        /// for records, or the metadata value after its marker for metadata.
+        offset: Option<usize>,
+        /// JSON-pointer-like path to the field (e.g., "/subdivisions").
         path: Option<String>,
     },
 
@@ -67,12 +92,17 @@ fn format_invalid_database(message: &str, offset: &Option<usize>) -> String {
     }
 }
 
-fn format_decoding_error(message: &str, offset: &Option<usize>, path: Option<&str>) -> String {
+fn format_contextual_error(
+    prefix: &str,
+    message: &str,
+    offset: &Option<usize>,
+    path: Option<&str>,
+) -> String {
     match (offset, path) {
-        (Some(off), Some(p)) => format!("decoding error at offset {off} (path: {p}): {message}"),
-        (Some(off), None) => format!("decoding error at offset {off}: {message}"),
-        (None, Some(p)) => format!("decoding error (path: {p}): {message}"),
-        (None, None) => format!("decoding error: {message}"),
+        (Some(off), Some(p)) => format!("{prefix} at offset {off} (path: {p}): {message}"),
+        (Some(off), None) => format!("{prefix} at offset {off}: {message}"),
+        (None, Some(p)) => format!("{prefix} (path: {p}): {message}"),
+        (None, None) => format!("{prefix}: {message}"),
     }
 }
 
@@ -121,6 +151,15 @@ impl MaxMindDbError {
             message: message.into(),
             offset: Some(offset),
             path: Some(path.into()),
+        }
+    }
+
+    /// Creates a ResourceLimit error with a message and offset.
+    pub fn resource_limit_at(message: impl Into<String>, offset: usize) -> Self {
+        MaxMindDbError::ResourceLimit {
+            message: message.into(),
+            offset: Some(offset),
+            path: None,
         }
     }
 
@@ -193,6 +232,14 @@ mod tests {
                 MaxMindDbError::decoding_at_path("unexpected type", 100, "/city/names/en")
             ),
             "decoding error at offset 100 (path: /city/names/en): unexpected type".to_owned(),
+        );
+
+        assert_eq!(
+            format!(
+                "{}",
+                MaxMindDbError::resource_limit_at("too many values", 100)
+            ),
+            "resource limit exceeded at offset 100: too many values".to_owned(),
         );
 
         let net_err = IpNetworkError::InvalidPrefix;

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,8 +50,8 @@ pub enum MaxMindDbError {
         path: Option<String>,
     },
 
-    /// Decoding stopped because the requested value exceeded a decoder-wide
-    /// expansion safety limit.
+    /// Decoding or verification stopped because it exceeded an expansion or
+    /// work safety limit.
     ///
     /// This does not necessarily mean that the database is structurally
     /// invalid. Schema-specific limits reported by a custom Serde visitor use

--- a/src/geoip2.rs
+++ b/src/geoip2.rs
@@ -55,7 +55,94 @@
 //! # }
 //! ```
 
-use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::marker::PhantomData;
+
+use serde::de::{IgnoredAny, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Maximum number of subdivisions accepted while deserializing the built-in
+/// City and Enterprise schemas.
+///
+/// Geographic records ordinarily contain only a small administrative
+/// hierarchy. This input constraint applies to every Serde format, not only
+/// MaxMind DB. The record fields remain public `Vec`s, so callers may still
+/// construct and serialize a value above the limit; deserializing it again will
+/// fail. Custom schemas should likewise apply a semantic limit to collection
+/// fields when decoding data that is not trusted.
+///
+/// An otherwise valid oversized MMDB list that reaches this visitor is reported
+/// as [`crate::MaxMindDbError::Decoding`]. Malformed input may instead produce
+/// [`crate::MaxMindDbError::InvalidDatabase`], and decoder-wide limits reported
+/// as [`crate::MaxMindDbError::ResourceLimit`] take precedence. Other Serde
+/// formats report their own deserializer error type.
+pub const MAX_SUBDIVISIONS: usize = 32;
+
+#[cold]
+fn subdivisions_too_long<E>() -> E
+where
+    E: serde::de::Error,
+{
+    E::custom(format_args!(
+        "subdivisions exceeds maximum length of {MAX_SUBDIVISIONS}"
+    ))
+}
+
+#[inline(always)]
+fn deserialize_subdivisions<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    struct SubdivisionsVisitor<T>(PhantomData<T>);
+
+    impl<'de, T> Visitor<'de> for SubdivisionsVisitor<T>
+    where
+        T: Deserialize<'de>,
+    {
+        type Value = Vec<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                formatter,
+                "an array containing at most {MAX_SUBDIVISIONS} subdivisions"
+            )
+        }
+
+        #[inline(always)]
+        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            if let Some(size) = sequence.size_hint() {
+                if size > MAX_SUBDIVISIONS {
+                    return Err(subdivisions_too_long());
+                }
+
+                let mut subdivisions = Vec::with_capacity(size);
+                while let Some(subdivision) = sequence.next_element()? {
+                    subdivisions.push(subdivision);
+                }
+                return Ok(subdivisions);
+            }
+
+            let mut subdivisions = Vec::new();
+            while subdivisions.len() < MAX_SUBDIVISIONS {
+                let Some(subdivision) = sequence.next_element()? else {
+                    return Ok(subdivisions);
+                };
+                subdivisions.push(subdivision);
+            }
+
+            if sequence.next_element::<IgnoredAny>()?.is_some() {
+                return Err(subdivisions_too_long());
+            }
+            Ok(subdivisions)
+        }
+    }
+
+    deserializer.deserialize_seq(SubdivisionsVisitor(PhantomData))
+}
 
 /// Localized names for geographic entities.
 ///
@@ -198,7 +285,14 @@ pub struct City<'a> {
     pub represented_country: city::RepresentedCountry<'a>,
     /// Subdivisions (states, provinces, etc.) ordered from largest to smallest.
     /// For example, Oxford, UK would have England first, then Oxfordshire.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Deserialization through any Serde format accepts at most
+    /// [`MAX_SUBDIVISIONS`] entries.
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_subdivisions",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub subdivisions: Vec<city::Subdivision<'a>>,
     /// Various traits associated with the IP address.
     #[serde(default, skip_serializing_if = "city::Traits::is_empty")]
@@ -237,7 +331,14 @@ pub struct Enterprise<'a> {
     )]
     pub represented_country: enterprise::RepresentedCountry<'a>,
     /// Subdivisions with confidence scores, ordered from largest to smallest.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Deserialization through any Serde format accepts at most
+    /// [`MAX_SUBDIVISIONS`] entries.
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_subdivisions",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub subdivisions: Vec<enterprise::Subdivision<'a>>,
     /// Extended traits including ISP, organization, and connection information.
     #[serde(default, skip_serializing_if = "enterprise::Traits::is_empty")]
@@ -693,4 +794,126 @@ pub mod enterprise {
     }
 
     impl_is_empty_via_default!(Traits<'_>);
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::de::value::{Error as ValueError, SeqDeserializer, U8Deserializer};
+    use serde::Deserialize;
+
+    use super::{deserialize_subdivisions, City, Enterprise, MAX_SUBDIVISIONS};
+    use crate::{decoder::Decoder, MaxMindDbError};
+
+    fn record_with_declared_subdivisions(declared_count: usize, encoded_count: usize) -> Vec<u8> {
+        assert!((29..=284).contains(&declared_count));
+        assert!(encoded_count <= declared_count);
+
+        let mut encoded = vec![0xe1, 0x4c]; // one-entry map, 12-byte key
+        encoded.extend_from_slice(b"subdivisions");
+        encoded.extend_from_slice(&[0x1d, 0x04, (declared_count - 29) as u8]);
+        encoded.resize(encoded.len() + encoded_count, 0xe0); // empty subdivision maps
+        encoded
+    }
+
+    fn record_with_subdivisions(count: usize) -> Vec<u8> {
+        record_with_declared_subdivisions(count, count)
+    }
+
+    struct UnknownSize<I>(I);
+
+    impl<I> Iterator for UnknownSize<I>
+    where
+        I: Iterator,
+    {
+        type Item = I::Item;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (0, None)
+        }
+    }
+
+    fn subdivisions_without_size_hint(count: usize) -> Result<Vec<u8>, ValueError> {
+        let values = (0..count).map(|_| U8Deserializer::<ValueError>::new(0));
+        deserialize_subdivisions(SeqDeserializer::new(UnknownSize(values)))
+    }
+
+    #[test]
+    fn city_accepts_maximum_subdivisions() {
+        let encoded = record_with_subdivisions(MAX_SUBDIVISIONS);
+        let city = City::deserialize(&mut Decoder::new(&encoded, 0)).unwrap();
+
+        assert_eq!(city.subdivisions.len(), MAX_SUBDIVISIONS);
+    }
+
+    #[test]
+    fn city_rejects_excessive_subdivisions() {
+        let encoded = record_with_subdivisions(MAX_SUBDIVISIONS + 1);
+        let err = City::deserialize(&mut Decoder::new(&encoded, 0)).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::Decoding { .. }));
+        assert!(err
+            .to_string()
+            .contains("subdivisions exceeds maximum length of 32"));
+    }
+
+    #[test]
+    fn enterprise_rejects_excessive_subdivisions() {
+        let encoded = record_with_subdivisions(MAX_SUBDIVISIONS + 1);
+        let err = Enterprise::deserialize(&mut Decoder::new(&encoded, 0)).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::Decoding { .. }));
+        assert!(err
+            .to_string()
+            .contains("subdivisions exceeds maximum length of 32"));
+    }
+
+    #[test]
+    fn subdivision_limit_does_not_depend_on_a_size_hint() {
+        let subdivisions = subdivisions_without_size_hint(MAX_SUBDIVISIONS).unwrap();
+        assert_eq!(subdivisions.len(), MAX_SUBDIVISIONS);
+
+        let err = subdivisions_without_size_hint(MAX_SUBDIVISIONS + 1).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("subdivisions exceeds maximum length of 32"));
+    }
+
+    #[test]
+    fn city_json_deserialization_enforces_subdivision_limit() {
+        let mut city = City::default();
+        city.subdivisions
+            .resize_with(MAX_SUBDIVISIONS, Default::default);
+        let json = serde_json::to_string(&city).unwrap();
+        let decoded = serde_json::from_str::<City<'_>>(&json).unwrap();
+        assert_eq!(decoded.subdivisions.len(), MAX_SUBDIVISIONS);
+
+        city.subdivisions.push(Default::default());
+        let json = serde_json::to_string(&city).unwrap();
+        let err = serde_json::from_str::<City<'_>>(&json).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("subdivisions exceeds maximum length of 32"));
+    }
+
+    #[test]
+    fn city_rejects_truncated_oversized_subdivisions() {
+        let encoded = record_with_declared_subdivisions(MAX_SUBDIVISIONS + 1, 1);
+        let err = City::deserialize(&mut Decoder::new(&encoded, 0)).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(err.to_string().contains("unexpected end of buffer"));
+    }
+
+    #[test]
+    fn enterprise_rejects_truncated_oversized_subdivisions() {
+        let encoded = record_with_declared_subdivisions(MAX_SUBDIVISIONS + 1, 1);
+        let err = Enterprise::deserialize(&mut Decoder::new(&encoded, 0)).unwrap_err();
+
+        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(err.to_string().contains("unexpected end of buffer"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub mod fuzzing {
 
     /// Validate one data-section value through the verification decoder.
     pub fn verify(data: &[u8]) -> Result<(), MaxMindDbError> {
-        Decoder::new(data, 0).skip_value_for_verification(&mut VerificationState::default())
+        Decoder::new(data, 0).skip_value_for_verification(&mut VerificationState::new(data.len()))
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -620,11 +620,22 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
     pub fn verify(&self) -> Result<(), MaxMindDbError> {
         let metadata_start = find_metadata_start(self.buf.as_ref())?;
         let data_section_end = metadata_marker_start(metadata_start)?;
-        self.verify_metadata(data_section_end)?;
+        self.verify_metadata(metadata_start, data_section_end)?;
         self.verify_database(data_section_end)
     }
 
-    fn verify_metadata(&self, data_section_end: usize) -> Result<(), MaxMindDbError> {
+    fn verify_metadata(
+        &self,
+        metadata_start: usize,
+        data_section_end: usize,
+    ) -> Result<(), MaxMindDbError> {
+        // Metadata deserialization intentionally ignores unknown fields. Verify
+        // the original value graph as well so an invalid or cyclic pointer in
+        // an unknown field cannot hide behind the cached typed representation.
+        let metadata_bytes = &self.buf.as_ref()[metadata_start..];
+        let mut decoder = decoder::Decoder::new(metadata_bytes, 0);
+        decoder.skip_value_for_verification(&mut decoder::VerificationState::default())?;
+
         let m = &self.metadata;
 
         validate_metadata_for_reader(m)?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -135,7 +135,8 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
         let data_section_end = metadata_marker_start(metadata_start)?;
         let metadata_bytes = &buf.as_ref()[metadata_start..];
         let mut type_decoder = decoder::Decoder::new(metadata_bytes, 0);
-        let metadata = Metadata::deserialize(&mut type_decoder)?;
+        let metadata = Metadata::deserialize(&mut type_decoder)
+            .map_err(|error| error.with_invalid_database_offset_base(metadata_start))?;
         validate_metadata_for_reader(&metadata)?;
 
         let search_tree_size =
@@ -634,7 +635,9 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
         // an unknown field cannot hide behind the cached typed representation.
         let metadata_bytes = &self.buf.as_ref()[metadata_start..];
         let mut decoder = decoder::Decoder::new(metadata_bytes, 0);
-        decoder.skip_value_for_verification(&mut decoder::VerificationState::default())?;
+        decoder
+            .skip_value_for_verification(&mut decoder::VerificationState::default())
+            .map_err(|error| error.with_invalid_database_offset_base(metadata_start))?;
 
         let m = &self.metadata;
 
@@ -726,18 +729,15 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
                         data_section.len()
                     ),
                     offset,
-                ));
+                )
+                .with_invalid_database_offset_base(self.pointer_base));
             }
 
             let mut dec = decoder::Decoder::new(data_section, offset);
 
             // Try to skip/decode the value to verify it's valid
-            if let Err(e) = dec.skip_value_for_verification(&mut verification_state) {
-                return Err(MaxMindDbError::invalid_database_at(
-                    format!("decoding error: {e}"),
-                    offset,
-                ));
-            }
+            dec.skip_value_for_verification(&mut verification_state)
+                .map_err(|error| error.with_invalid_database_offset_base(self.pointer_base))?;
         }
 
         Ok(())

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -605,7 +605,11 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
     /// Note: Verification traverses the entire database and retains visited data
     /// offsets for the duration of the call. It may be slow and use memory
     /// proportional to the number of distinct referenced values on large files.
-    /// Verification validates each shared target once. Later deserialization
+    /// Verification validates each shared target once. For each metadata or
+    /// data section, it permits up to eight times the section's byte length in
+    /// work units: one per visited value and one per string byte validated.
+    /// Exceeding this allowance returns [`MaxMindDbError::ResourceLimit`],
+    /// bounding repeated scans of overlapping payloads. Later deserialization
     /// independently applies the per-operation container and payload limits
     /// documented on [`crate::LookupResult::decode()`]. The method is
     /// thread-safe and can be called on an active Reader.
@@ -636,7 +640,7 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
         let metadata_bytes = &self.buf.as_ref()[metadata_start..];
         let mut decoder = decoder::Decoder::new(metadata_bytes, 0);
         decoder
-            .skip_value_for_verification(&mut decoder::VerificationState::default())
+            .skip_value_for_verification(&mut decoder::VerificationState::new(metadata_bytes.len()))
             .map_err(|error| error.with_invalid_database_offset_base(metadata_start))?;
 
         let m = &self.metadata;
@@ -718,7 +722,7 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
         data_section_end: usize,
     ) -> Result<(), MaxMindDbError> {
         let data_section = &self.buf.as_ref()[self.pointer_base..data_section_end];
-        let mut verification_state = decoder::VerificationState::default();
+        let mut verification_state = decoder::VerificationState::new(data_section.len());
 
         // Verify each offset from the search tree points to valid, decodable data
         for &offset in &offsets {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -133,7 +133,8 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
         // find_metadata_start returns the offset after the marker; the marker
         // bytes are not part of the data section and must stay out of limits.
         let data_section_end = metadata_marker_start(metadata_start)?;
-        let mut type_decoder = decoder::Decoder::new(&buf.as_ref()[metadata_start..], 0);
+        let metadata_bytes = &buf.as_ref()[metadata_start..];
+        let mut type_decoder = decoder::Decoder::new(metadata_bytes, 0);
         let metadata = Metadata::deserialize(&mut type_decoder)?;
         validate_metadata_for_reader(&metadata)?;
 
@@ -603,7 +604,10 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
     /// Note: Verification traverses the entire database and retains visited data
     /// offsets for the duration of the call. It may be slow and use memory
     /// proportional to the number of distinct referenced values on large files.
-    /// The method is thread-safe and can be called on an active Reader.
+    /// Verification validates each shared target once. Later deserialization
+    /// independently applies the per-operation container and payload limits
+    /// documented on [`crate::LookupResult::decode()`]. The method is
+    /// thread-safe and can be called on an active Reader.
     ///
     /// # Example
     ///

--- a/src/reader_test.rs
+++ b/src/reader_test.rs
@@ -1207,6 +1207,27 @@ fn test_verify_good_databases() {
     }
 }
 
+#[test]
+fn test_verify_rejects_invalid_pointer_in_unknown_metadata_field() {
+    let source_path = "test-data/test-data/MaxMind-DB-test-ipv4-24.mmdb";
+    let original = Reader::open_readfile(source_path).unwrap();
+    let metadata_start = original.metadata_start;
+    let mut bytes = std::fs::read(source_path).unwrap();
+
+    assert_eq!(bytes[metadata_start], 0xe9, "unexpected metadata map size");
+    bytes[metadata_start] = 0xea; // add one map entry
+    bytes.push(0x47); // seven-byte string key
+    bytes.extend_from_slice(b"unknown");
+    bytes.extend_from_slice(&[0x20, 0xff]); // pointer beyond the metadata buffer
+
+    // Typed metadata parsing skips the unknown value without following its
+    // pointer, so normal reader construction remains lazy.
+    let reader = Reader::from_source(bytes).unwrap();
+    let err = reader.verify().unwrap_err();
+
+    assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+}
+
 /// Test that verify() returns errors on broken databases (matching Go's TestVerifyOnBrokenDatabases)
 #[test]
 fn test_verify_broken_double_format() {

--- a/src/reader_test.rs
+++ b/src/reader_test.rs
@@ -1273,6 +1273,89 @@ fn test_verify_rejects_invalid_pointer_in_unknown_metadata_field() {
 }
 
 #[test]
+fn test_verify_bounds_overlapping_strings_in_unknown_metadata() {
+    let source_path = "test-data/test-data/MaxMind-DB-test-ipv4-24.mmdb";
+    let original = Reader::open_readfile(source_path).unwrap();
+    let metadata_start = original.metadata_start;
+    let mut bytes = std::fs::read(source_path).unwrap();
+    assert_eq!(bytes[metadata_start], 0xe9);
+    bytes[metadata_start] = 0xea;
+    bytes.push(0x47);
+    bytes.extend_from_slice(b"unknown");
+    bytes.extend_from_slice(&four_byte_pointer(bytes.len() + 5 - metadata_start));
+
+    const COUNT: usize = 64;
+    bytes.extend_from_slice(&[0x1d, 0x04, (COUNT - 29) as u8]);
+    let strings_offset = bytes.len() + COUNT * 5 - metadata_start;
+    for index in 0..COUNT {
+        bytes.extend_from_slice(&four_byte_pointer(strings_offset + index * 4));
+    }
+    // String headers are valid ASCII within the overlapping payloads. A
+    // roughly 133 KiB file would otherwise require over 8 MiB of UTF-8 scans.
+    for _ in 0..COUNT {
+        bytes.extend_from_slice(&[0x5f, 0x01, 0x00, 0x00]);
+    }
+    bytes.resize(bytes.len() + 65_821 + 65_536, b'a');
+
+    let reader = Reader::from_source(bytes).unwrap();
+    let err = reader.verify().unwrap_err();
+    assert!(matches!(
+        err,
+        MaxMindDbError::ResourceLimit { message, offset: Some(offset), path: None }
+            if message == "exceeded maximum verification work"
+                && offset == strings_offset + 8 * 4 + 4
+    ));
+}
+
+#[test]
+fn test_verify_shares_work_allowance_across_data_roots() {
+    let source_path = "test-data/test-data/MaxMind-DB-test-ipv4-24.mmdb";
+    let source = std::fs::read(source_path).unwrap();
+    let original = Reader::from_source(source.as_slice()).unwrap();
+    assert_eq!(original.metadata().record_size, 24);
+    let node_count = original.metadata().node_count as usize;
+
+    const ROOT_COUNT: usize = 16;
+    let make_reader = |distinct_roots: usize| {
+        let mut bytes = source[..original.pointer_base].to_vec();
+        let mut leaf_count = 0;
+        for record in bytes[..node_count * 6].as_chunks_mut::<3>().0 {
+            let pointer = u32::from_be_bytes([0, record[0], record[1], record[2]]) as usize;
+            if pointer >= node_count {
+                // Preserve the tree, redirecting both empty and data leaves
+                // to the overlapping string headers in the new data section.
+                let offset = (leaf_count % distinct_roots) * 4;
+                let target = u32::try_from(node_count + 16 + offset).unwrap();
+                assert!(target <= 0x00ff_ffff);
+                record.copy_from_slice(&target.to_be_bytes()[1..]);
+                leaf_count += 1;
+            }
+        }
+        assert!(leaf_count >= ROOT_COUNT);
+
+        // Each string has a 131,357-byte payload, and its header is valid
+        // ASCII inside earlier strings. Nine scans exceed the allowance for
+        // this data section, including all headers and the trailing payload.
+        for _ in 0..ROOT_COUNT {
+            bytes.extend_from_slice(&[0x5f, 0x01, 0x00, 0x00]);
+        }
+        bytes.resize(bytes.len() + 65_821 + 65_536, b'a');
+        bytes.extend_from_slice(&source[original.pointer_base + original.data_section_len..]);
+        Reader::from_source(bytes).unwrap()
+    };
+
+    // Repeated references to one root fit because verification caches it.
+    make_reader(1).verify().unwrap();
+    let err = make_reader(ROOT_COUNT).verify().unwrap_err();
+    // Root iteration uses a HashSet, so the failing offset is unspecified.
+    assert!(matches!(
+        err,
+        MaxMindDbError::ResourceLimit { message, .. }
+            if message == "exceeded maximum verification work"
+    ));
+}
+
+#[test]
 fn test_from_source_reports_absolute_metadata_offset() {
     let source_path = "test-data/test-data/MaxMind-DB-test-ipv4-24.mmdb";
     let original = Reader::open_readfile(source_path).unwrap();

--- a/src/reader_test.rs
+++ b/src/reader_test.rs
@@ -68,6 +68,12 @@ fn collect_networks<S: AsRef<[u8]>>(iter: Within<'_, S>) -> Vec<String> {
     .collect()
 }
 
+fn four_byte_pointer(target: usize) -> [u8; 5] {
+    let target = u32::try_from(target).expect("test pointer target must fit in four bytes");
+    let bytes = target.to_be_bytes();
+    [0x38, bytes[0], bytes[1], bytes[2], bytes[3]]
+}
+
 #[allow(clippy::float_cmp)]
 #[test]
 fn test_decoder() {
@@ -979,6 +985,38 @@ fn test_skip_empty_values_with_other_options() {
     assert!(count > 0, "Should have some networks");
 }
 
+#[test]
+fn test_skip_empty_values_reports_absolute_file_offset() {
+    let source_path = "test-data/test-data/MaxMind-DB-test-ipv4-24.mmdb";
+    let original = Reader::open_readfile(source_path).unwrap();
+    let data_offset = original
+        .lookup("1.1.1.32".parse().unwrap())
+        .unwrap()
+        .offset()
+        .unwrap();
+    let record_start = original.pointer_base + data_offset;
+    let expected_offset = original.pointer_base + original.data_section_len;
+    let pointer = four_byte_pointer(original.data_section_len);
+    let mut bytes = std::fs::read(source_path).unwrap();
+    bytes[record_start..record_start + pointer.len()].copy_from_slice(&pointer);
+
+    let reader = Reader::from_source(bytes).unwrap();
+    let options = WithinOptions::default().skip_empty_values();
+    let err = reader
+        .networks(options)
+        .unwrap()
+        .find_map(Result::err)
+        .expect("iterator should encounter the malformed record");
+
+    assert!(matches!(
+        err,
+        MaxMindDbError::InvalidDatabase {
+            offset: Some(offset),
+            ..
+        } if offset == expected_offset
+    ));
+}
+
 /// Test various NetworksWithin scenarios matching Go tests
 #[test]
 fn test_networks_within_scenarios() {
@@ -1225,7 +1263,40 @@ fn test_verify_rejects_invalid_pointer_in_unknown_metadata_field() {
     let reader = Reader::from_source(bytes).unwrap();
     let err = reader.verify().unwrap_err();
 
-    assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+    assert!(matches!(
+        err,
+        MaxMindDbError::InvalidDatabase {
+            offset: Some(offset),
+            ..
+        } if offset == metadata_start + 255
+    ));
+}
+
+#[test]
+fn test_from_source_reports_absolute_metadata_offset() {
+    let source_path = "test-data/test-data/MaxMind-DB-test-ipv4-24.mmdb";
+    let original = Reader::open_readfile(source_path).unwrap();
+    let metadata_start = original.metadata_start;
+    let mut bytes = std::fs::read(source_path).unwrap();
+    let metadata_len = bytes.len() - metadata_start;
+    let database_type = b"database_type";
+    let key_start = bytes[metadata_start..]
+        .windows(database_type.len())
+        .position(|window| window == database_type)
+        .map(|offset| metadata_start + offset)
+        .expect("metadata should contain database_type");
+    let value_start = key_start + database_type.len();
+    let pointer = four_byte_pointer(metadata_len);
+    bytes[value_start..value_start + pointer.len()].copy_from_slice(&pointer);
+
+    let err = Reader::from_source(bytes).unwrap_err();
+    assert!(matches!(
+        err,
+        MaxMindDbError::InvalidDatabase {
+            offset: Some(offset),
+            ..
+        } if offset == metadata_start + metadata_len
+    ));
 }
 
 /// Test that verify() returns errors on broken databases (matching Go's TestVerifyOnBrokenDatabases)
@@ -1339,7 +1410,13 @@ fn test_verify_rejects_truncated_scalar_value() {
     let reader = Reader::from_source(bytes).unwrap();
     let result = reader.verify();
     assert!(
-        matches!(result, Err(MaxMindDbError::InvalidDatabase { .. })),
+        matches!(
+            result,
+            Err(MaxMindDbError::InvalidDatabase {
+                offset: Some(offset),
+                ..
+            }) if offset == string_ctrl_offset + 1
+        ),
         "Expected InvalidDatabase error for truncated scalar payload, got {:?}",
         result
     );
@@ -1378,7 +1455,24 @@ fn test_decode_rejects_truncated_ignored_scalar_value() {
     let lookup = reader.lookup("1.1.1.32".parse().unwrap()).unwrap();
     let err = lookup.decode::<Empty>().unwrap_err();
 
-    assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+    assert!(matches!(
+        err,
+        MaxMindDbError::InvalidDatabase {
+            offset: Some(offset),
+            ..
+        } if offset == string_ctrl_offset + 1
+    ));
+
+    let err = lookup
+        .decode_path::<String>(&[crate::PathElement::Key("ip")])
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        MaxMindDbError::InvalidDatabase {
+            offset: Some(offset),
+            ..
+        } if offset == string_ctrl_offset + 1
+    ));
 }
 
 #[test]

--- a/src/reader_test.rs
+++ b/src/reader_test.rs
@@ -21,6 +21,42 @@ fn open_test_data_reader(database: &str) -> Reader<Vec<u8>> {
         .unwrap_or_else(|e| panic!("failed to open test database '{database}': {e}"))
 }
 
+#[derive(Debug)]
+struct OwnedBytes(Vec<u8>);
+
+impl<'de> Deserialize<'de> for OwnedBytes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct OwnedBytesVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for OwnedBytesVisitor {
+            type Value = OwnedBytes;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a bytes value")
+            }
+
+            fn visit_borrowed_bytes<E>(self, value: &'de [u8]) -> Result<Self::Value, E> {
+                Ok(OwnedBytes(value.to_vec()))
+            }
+
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E> {
+                Ok(OwnedBytes(value.to_vec()))
+            }
+
+            fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Self::Value, E> {
+                Ok(OwnedBytes(value))
+            }
+        }
+
+        // Enter through `deserialize_any`, which is the dynamically shaped
+        // boundary protected by the decoder's expansion budget.
+        deserializer.deserialize_any(OwnedBytesVisitor)
+    }
+}
+
 fn collect_networks<S: AsRef<[u8]>>(iter: Within<'_, S>) -> Vec<String> {
     iter.map(|result| {
         result
@@ -1549,4 +1585,197 @@ fn test_verify_follows_and_rejects_invalid_data_pointers() {
     let err = reader.verify().unwrap_err();
     assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
     assert!(err.to_string().contains("unexpected end of buffer"));
+}
+
+#[test]
+fn test_pointer_fan_out_is_rejected() {
+    init_logger();
+
+    // A data section of nested arrays, each holding two pointers to the node
+    // below, would cost 2**depth decode operations. The decoder bounds the
+    // number of values it decodes for a single record and rejects decoding the
+    // record.
+    let reader = open_test_data_reader("MaxMind-DB-test-pointer-decoder-dos.mmdb");
+    let ip = "1.2.3.4".parse().unwrap();
+    let result: Result<Option<serde_json::Value>, _> = reader.lookup(ip).unwrap().decode();
+    match result {
+        Ok(_) => panic!("expected the fan-out record decode to be rejected"),
+        Err(e) => assert!(
+            matches!(&e, MaxMindDbError::ResourceLimit { message, .. }
+                if message.contains("maximum number of data structure values")),
+            "unexpected error: {e}"
+        ),
+    }
+}
+
+#[test]
+fn test_payload_amplification_is_rejected() {
+    init_logger();
+
+    // Each bytes fixture aims many pointers at one large value. `OwnedBytes`
+    // enters through deserialize_any before copying, so materializing the
+    // pointed-to bytes must trip the dynamic payload budget well before the
+    // value-count budget.
+    for database in [
+        "MaxMind-DB-test-payload-amplification-dos.mmdb",
+        "MaxMind-DB-test-payload-amplification-dos-worst-case.mmdb",
+    ] {
+        let reader = open_test_data_reader(database);
+        let ip = "1.2.3.4".parse().unwrap();
+        let result: Result<Option<Vec<OwnedBytes>>, _> = reader.lookup(ip).unwrap().decode();
+        assert!(
+            matches!(&result, Err(MaxMindDbError::ResourceLimit { message, .. })
+                if message.contains("maximum size of data structure string and bytes")),
+            "unexpected result for {database}: {result:?}"
+        );
+    }
+
+    // The UTF-8 string variant also trips the budget when materialized into an
+    // owned dynamic value, the shape a real consumer copies into.
+    let reader = open_test_data_reader("MaxMind-DB-test-payload-amplification-dos-string.mmdb");
+    let ip = "1.2.3.4".parse().unwrap();
+    let result: Result<Option<serde_json::Value>, _> = reader.lookup(ip).unwrap().decode();
+    assert!(
+        matches!(&result, Err(MaxMindDbError::ResourceLimit { message, .. })
+            if message.contains("maximum size of data structure string and bytes")),
+        "unexpected result for string fixture into Value: {result:?}"
+    );
+
+    // Concrete collection decoding enters through deserialize_seq rather than
+    // deserialize_any and receives the same aggregate payload protection.
+    let result: Result<Option<Vec<String>>, _> = reader.lookup(ip).unwrap().decode();
+    assert!(
+        matches!(&result, Err(MaxMindDbError::ResourceLimit { message, .. })
+            if message.contains("maximum size of data structure string and bytes")),
+        "unexpected result for string fixture into Vec<String>: {result:?}"
+    );
+
+    // A normal record still decodes into a generic value.
+    let reader = open_test_data_reader("GeoIP2-City-Test.mmdb");
+    let ip = "89.160.20.128".parse().unwrap();
+    let value: Option<serde_json::Value> = reader
+        .lookup(ip)
+        .unwrap()
+        .decode()
+        .expect("normal record should decode");
+    assert!(value.is_some(), "expected a record for the test address");
+}
+
+#[test]
+fn test_decoder_resource_limit_boundaries() {
+    let ip = "1.2.3.4".parse().unwrap();
+
+    for database in [
+        "MaxMind-DB-test-decoder-value-limit.mmdb",
+        "MaxMind-DB-test-decoder-value-limit-pointer-heavy.mmdb",
+    ] {
+        let reader = open_test_data_reader(database);
+        let result: Result<Option<serde_json::Value>, _> = reader.lookup(ip).unwrap().decode();
+        assert!(
+            result.is_ok(),
+            "expected {database} to be accepted: {result:?}"
+        );
+    }
+
+    let reader = open_test_data_reader("MaxMind-DB-test-decoder-value-limit-over.mmdb");
+    let lookup = reader.lookup(ip).unwrap();
+    let result: Result<Option<serde_json::Value>, _> = lookup.decode();
+    assert!(
+        matches!(&result, Err(MaxMindDbError::ResourceLimit { message, .. })
+            if message.contains("maximum number of data structure values")),
+        "unexpected result above the value limit: {result:?}"
+    );
+
+    let path_result: Result<Option<serde_json::Value>, _> = lookup.decode_path(&[]);
+    assert!(
+        matches!(&path_result, Err(MaxMindDbError::ResourceLimit { message, .. })
+            if message.contains("maximum number of data structure values")),
+        "unexpected decode_path result above the value limit: {path_result:?}"
+    );
+
+    let reader = open_test_data_reader("MaxMind-DB-test-decoder-payload-limit.mmdb");
+    let result: Result<Option<Vec<OwnedBytes>>, _> = reader.lookup(ip).unwrap().decode();
+    let values = result
+        .expect("expected exact payload limit to be accepted")
+        .expect("expected a record at the test address");
+    assert_eq!(
+        values.iter().map(|value| value.0.len()).sum::<usize>(),
+        2 << 20
+    );
+
+    let reader = open_test_data_reader("MaxMind-DB-test-decoder-payload-limit-over.mmdb");
+    let result: Result<Option<Vec<OwnedBytes>>, _> = reader.lookup(ip).unwrap().decode();
+    assert!(
+        matches!(&result, Err(MaxMindDbError::ResourceLimit { message, .. })
+            if message.contains("maximum size of data structure string and bytes")),
+        "unexpected result above the payload limit: {result:?}"
+    );
+}
+
+#[test]
+fn test_decode_path_navigation_and_value_share_payload_budget() {
+    let reader = open_test_data_reader("MaxMind-DB-test-decode-path-shared-budget.mmdb");
+    let lookup = reader.lookup("1.2.3.4".parse().unwrap()).unwrap();
+    let err = lookup
+        .decode_path::<String>(&[crate::PathElement::Key("target")])
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            &err,
+            MaxMindDbError::ResourceLimit {
+                message,
+                path: Some(path),
+                ..
+            } if message.contains("maximum size of data structure string and bytes")
+                && path == "/target"
+        ),
+        "unexpected cumulative decode_path result: {err}"
+    );
+}
+
+#[test]
+fn test_decode_path_navigation_shares_logical_value_budget_across_hops() {
+    let mut reader = open_test_data_reader("MaxMind-DB-test-ipv4-24.mmdb");
+    let ip = "1.1.1.1".parse().unwrap();
+    let data_offset = reader.lookup(ip).unwrap().offset().unwrap();
+    let record_start = reader.pointer_base + data_offset;
+
+    // Replace the record with two nested arrays that each declare 32,768
+    // children. Either declaration fits independently, but their cumulative
+    // reservations plus the top-level value exceed the 65,536-value budget by
+    // one. The second header is reached through a real, nonempty path.
+    let array_header = [0x1e, 0x04, 0x7e, 0xe3];
+    reader.buf[record_start..record_start + 4].copy_from_slice(&array_header);
+    reader.buf[record_start + 4..record_start + 8].copy_from_slice(&array_header);
+
+    let err = reader
+        .lookup(ip)
+        .unwrap()
+        .decode_path::<u16>(&[crate::PathElement::Index(0), crate::PathElement::Index(0)])
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            &err,
+            MaxMindDbError::ResourceLimit {
+                message,
+                path: Some(path),
+                ..
+            } if message.contains("maximum number of data structure values")
+                && path == "/0/0"
+        ),
+        "unexpected cumulative decode_path result: {err}"
+    );
+}
+
+#[test]
+fn test_metadata_payload_amplification_is_rejected() {
+    let result =
+        Reader::open_readfile("test-data/test-data/MaxMind-DB-test-metadata-payload-limit.mmdb");
+    assert!(
+        matches!(&result, Err(MaxMindDbError::ResourceLimit { message, .. })
+            if message.contains("maximum size of data structure string and bytes")),
+        "unexpected metadata amplification result: {result:?}"
+    );
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -232,7 +232,9 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
         };
 
         let mut decoder = self.decoder(offset);
-        T::deserialize(&mut decoder).map(Some)
+        T::deserialize(&mut decoder)
+            .map(Some)
+            .map_err(|error| error.with_invalid_database_offset_base(self.reader.pointer_base))
     }
 
     /// Decodes a value at a specific path within the record.
@@ -276,6 +278,15 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
     ///     .unwrap();
     /// ```
     pub fn decode_path<T>(&self, path: &[PathElement<'_>]) -> Result<Option<T>, MaxMindDbError>
+    where
+        T: Deserialize<'a>,
+    {
+        self.decode_path_relative(path)
+            .map_err(|error| error.with_invalid_database_offset_base(self.reader.pointer_base))
+    }
+
+    #[inline]
+    fn decode_path_relative<T>(&self, path: &[PathElement<'_>]) -> Result<Option<T>, MaxMindDbError>
     where
         T: Deserialize<'a>,
     {
@@ -359,7 +370,7 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
         // Decode the value at the current position
         T::deserialize(&mut decoder)
             .map(Some)
-            .map_err(|e| add_path_context(e, path))
+            .map_err(|error| add_path_context(error, path))
     }
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -223,6 +223,7 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
     /// }
     /// # Ok::<(), maxminddb::MaxMindDbError>(())
     /// ```
+    #[inline]
     pub fn decode<T>(&self) -> Result<Option<T>, MaxMindDbError>
     where
         T: Deserialize<'a>,

--- a/src/result.rs
+++ b/src/result.rs
@@ -199,6 +199,12 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
     /// application's schema. A collection with a small semantic maximum should
     /// enforce it in its `Deserialize` implementation or a Serde
     /// `deserialize_with` visitor, before allocating or consuming its elements.
+    /// The built-in [`crate::geoip2::City`] and [`crate::geoip2::Enterprise`]
+    /// schemas cap their subdivision lists at
+    /// [`crate::geoip2::MAX_SUBDIVISIONS`] in every Serde format. An otherwise
+    /// valid oversized MMDB list that reaches the schema visitor returns
+    /// [`MaxMindDbError::Decoding`]; malformed data and decoder-wide limits may
+    /// fail earlier with their corresponding error variants.
     /// Custom deserializers that bypass Serde's map and sequence entry points
     /// remain responsible for bounding their own traversal over untrusted data.
     ///

--- a/src/result.rs
+++ b/src/result.rs
@@ -175,6 +175,33 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
     /// - `Ok(None)` if the IP was not found in the database
     /// - `Err(...)` if decoding fails
     ///
+    /// Any operation that enters an MMDB map or array has an expansion budget
+    /// of 65,536 logical values and 2 MiB of string and bytes payload. Dynamic
+    /// `deserialize_any`, enum, and raw-string-helper entry points activate the
+    /// budget before the value's type is known. Only scalar values requested
+    /// directly through a typed scalar entry point avoid this bookkeeping. The
+    /// decoder reserves a container's declared children before Serde can
+    /// allocate for them, repeated pointer targets are charged on every
+    /// expansion, and ignored fields do not expand pointer targets. Exceeding
+    /// either decoder-wide operation limit returns
+    /// [`MaxMindDbError::ResourceLimit`] rather than treating the database as
+    /// necessarily corrupt.
+    ///
+    /// Concrete-schema identifiers get a 32-byte allowance per logical value
+    /// before using the 2 MiB payload counter, whether they are encoded inline
+    /// or behind a pointer. The logical-value limit bounds all such allowances
+    /// to another 2 MiB. Thus, after an operation activates its budget,
+    /// expanded string and byte payload remains bounded to at most 4 MiB even
+    /// for custom identifier visitors. A scalar-only typed decode remains
+    /// limited only by the MMDB format's maximum encoded payload size.
+    ///
+    /// These general limits do not replace tighter bounds implied by an
+    /// application's schema. A collection with a small semantic maximum should
+    /// enforce it in its `Deserialize` implementation or a Serde
+    /// `deserialize_with` visitor, before allocating or consuming its elements.
+    /// Custom deserializers that bypass Serde's map and sequence entry points
+    /// remain responsible for bounding their own traversal over untrusted data.
+    ///
     /// # Example
     ///
     /// ```
@@ -210,6 +237,10 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
     /// - `Err(...)` if there's a type mismatch during navigation (e.g., `Key` on an array)
     ///
     /// If `has_data() == false`, returns `Ok(None)`.
+    /// Path traversal does not expand skipped pointer targets. Navigation and
+    /// the selected value share the container and payload budgets described by
+    /// [`decode()`](Self::decode); resource-limit errors include the path reached
+    /// when the limit was detected.
     ///
     /// # Path Elements
     ///
@@ -340,7 +371,8 @@ fn container_type_mismatch(
     }
 }
 
-/// Adds path context to a Decoding error if it doesn't already have one.
+/// Adds path context to a decoding or resource-limit error if it does not
+/// already have one.
 fn add_path_context(err: MaxMindDbError, path: &[PathElement<'_>]) -> MaxMindDbError {
     match err {
         MaxMindDbError::Decoding {
@@ -348,6 +380,15 @@ fn add_path_context(err: MaxMindDbError, path: &[PathElement<'_>]) -> MaxMindDbE
             offset,
             path: None,
         } => MaxMindDbError::Decoding {
+            message,
+            offset,
+            path: Some(render_path(path)),
+        },
+        MaxMindDbError::ResourceLimit {
+            message,
+            offset,
+            path: None,
+        } => MaxMindDbError::ResourceLimit {
             message,
             offset,
             path: Some(render_path(path)),
@@ -741,5 +782,21 @@ mod tests {
 
         assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
         assert!(err.to_string().contains("unknown data type: 256"));
+    }
+
+    #[test]
+    fn test_resource_limit_error_includes_path() {
+        let err = add_path_context(
+            MaxMindDbError::resource_limit_at("too many values", 7),
+            &[PathElement::Key("subdivisions")],
+        );
+
+        assert!(matches!(
+            err,
+            MaxMindDbError::ResourceLimit {
+                path: Some(ref path),
+                ..
+            } if path == "/subdivisions"
+        ));
     }
 }

--- a/src/within.rs
+++ b/src/within.rs
@@ -286,7 +286,9 @@ impl<'de, S: AsRef<[u8]>> Within<'de, S> {
         let buf = &self.reader.buf.as_ref()[self.reader.pointer_base..];
         let mut dec =
             decoder::Decoder::new_with_limit(buf, data_offset, self.reader.data_section_len);
-        let (size, type_num) = dec.peek_type()?;
+        let (size, type_num) = dec
+            .peek_type()
+            .map_err(|error| error.with_invalid_database_offset_base(self.reader.pointer_base))?;
         match type_num {
             decoder::TYPE_MAP | decoder::TYPE_ARRAY => Ok(size == 0),
             _ => Ok(false), // Non-container types are never "empty"


### PR DESCRIPTION
Bounds excessive decoding and verification work from crafted MMDB pointer graphs and overlapping string payloads. This is the Rust fix for `GHSA-5mfc-p3f9-5php`.

- Limit budgeted decoding to 65,536 logical values and a 2 MiB payload budget, plus a bounded identifier allowance. Share limits across path navigation and decoding.
- Bound verification work to eight times each section's size, including unknown metadata fields and distinct data roots.
- Skip unrequested pointer targets, cap built-in subdivision lists at 32, and report resource-limit failures distinctly.
- Include absolute invalid-data offsets, decoding optimizations, and tested release-version updates.

Validation: all seven commits pass default and feature tests, Clippy, rustdoc, and applicable formatting checks. Release-helper tests also pass.
