### PR TITLE
Improve record decoding performance and remove simdutf8

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,7 +19,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build documentation with warnings denied
-        run: cargo doc --all --features mmap,simdutf8 --no-deps
+        run: cargo doc --all --features mmap --no-deps
         env:
           RUSTDOCFLAGS: -D warnings
 
@@ -37,7 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Documentation
-        run: cargo doc --all --features mmap,simdutf8 --no-deps
+        run: cargo doc --all --features mmap --no-deps
         env:
           RUSTDOCFLAGS: -D warnings
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Run cargo check
-        run: cargo check --features mmap,simdutf8
+        run: cargo check --features mmap
 
   test:
     name: Test Suite
@@ -58,8 +58,6 @@ jobs:
         include:
           - platform: ubuntu-latest
             features: mmap
-          - platform: ubuntu-latest
-            features: mmap,simdutf8
           - platform: ubuntu-latest
             features: unsafe-str-decode
           - platform: ubuntu-latest
@@ -96,7 +94,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo clippy --all-targets --features mmap,simdutf8 -- -D warnings
+        run: cargo clippy --all-targets --features mmap -- -D warnings
 
       - name: Test release helpers
         run: bash dev-bin/release-lib-test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+- Breaking: Removed the `simdutf8` feature and its optional dependency. It did
+  not improve lookup performance in benchmarks using production GeoIP2 City
+  and Country databases. Remove `simdutf8` from dependency feature lists when
+  upgrading.
+
 ## 0.31.0 - 2026-09-07
 
 - Fixed a denial-of-service issue when decoding records or metadata. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   not improve lookup performance in benchmarks using production GeoIP2 City
   and Country databases. Remove `simdutf8` from dependency feature lists when
   upgrading.
+- Improved record decoding performance by reducing internal error storage.
+  Public error types and validation limits are unchanged.
 
 ## 0.31.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Improved record decoding performance by reducing internal error storage
   and streamlining pointer and payload decoding. Public error types and
   validation limits are unchanged.
+- Fixed decoder cursor restoration when a typed pointer exceeds the nesting
+  limit.
 
 ## 0.31.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
   not improve lookup performance in benchmarks using production GeoIP2 City
   and Country databases. Remove `simdutf8` from dependency feature lists when
   upgrading.
-- Improved record decoding performance by reducing internal error storage.
-  Public error types and validation limits are unchanged.
+- Improved record decoding performance by reducing internal error storage
+  and streamlining payload decoding. Public error types and validation limits
+  are unchanged.
 
 ## 0.31.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
   and Country databases. Remove `simdutf8` from dependency feature lists when
   upgrading.
 - Improved record decoding performance by reducing internal error storage
-  and streamlining payload decoding. Public error types and validation limits
-  are unchanged.
+  and streamlining pointer and payload decoding. Public error types and
+  validation limits are unchanged.
 
 ## 0.31.0 - 2026-09-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,9 @@ edition = "2021"
 
 [features]
 default = []
-# SIMD-accelerated UTF-8 validation during string decoding
-simdutf8 = ["dep:simdutf8"]
 # Memory-mapped file access for better performance in long-running applications
 mmap = ["memmap2"]
 # Skip UTF-8 validation for trusted Rust-native string decoding
-# (mutually exclusive with simdutf8)
 unsafe-str-decode = []
 # Internal entry points used by the cargo-fuzz targets.
 fuzzing = []
@@ -33,7 +30,6 @@ ipnetwork = "0.21.1"
 serde = { version = "1.0", features = ["derive"] }
 memchr = "2.4"
 memmap2 = { version = "0.9.0", optional = true }
-simdutf8 = { version = "0.1.5", optional = true }
 thiserror = "2.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ See the [examples](examples/) directory for runnable programs, including:
 Optional features:
 
 - **`mmap`**: Memory-mapped file access for long-running applications
-- **`simdutf8`**: SIMD-accelerated UTF-8 validation
 - **`unsafe-str-decode`**: Skip UTF-8 validation when deserializing trusted
   database strings into Rust `str` or `String` values. Cross-runtime format
   adapters should prefer `deserialize_any_with_raw_strings()` and validate
@@ -118,8 +117,6 @@ Enable in `Cargo.toml`:
 [dependencies]
 maxminddb = { version = "0.31", features = ["mmap"] }
 ```
-
-Note: `simdutf8` and `unsafe-str-decode` are mutually exclusive.
 
 ## Documentation
 

--- a/dev-bin/release-lib-test.sh
+++ b/dev-bin/release-lib-test.sh
@@ -17,7 +17,7 @@ supported_readme="$release_test_dir/supported.md"
 printf '%s\n' \
     'maxminddb = "0.29"' \
     'maxminddb = { version = "0.30", features = ["mmap"] }' \
-    'maxminddb = { features = ["simdutf8"], version = "0.28" }' \
+    'maxminddb = { features = ["mmap"], version = "0.28" }' \
     'other = { version = "9.99" }' \
     >"$supported_readme"
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -788,7 +788,10 @@ impl<'de> Decoder<'de> {
                 let new_ptr = self.decode_pointer(size);
                 let saved_ptr = self.current_ptr;
                 self.current_ptr = new_ptr;
-                self.enter_nested()?;
+                if let Err(error) = self.enter_nested() {
+                    self.current_ptr = saved_ptr;
+                    return Err(error);
+                }
                 let header = self.size_and_type().and_then(|(size, type_num)| {
                     if type_num == TYPE_POINTER {
                         Err(self.invalid_db_error("pointer points to another pointer"))
@@ -2257,6 +2260,33 @@ mod tests {
             assert_eq!(decoder.state & super::DEPTH_MASK, 0);
             assert_eq!(u16::deserialize(&mut decoder).unwrap(), 42);
         }
+    }
+
+    #[test]
+    fn typed_pointer_depth_limit_restores_continuation() {
+        let buf = [0x20, 4, 0xa1, 42, 0x41, b'x'];
+        let mut decoder = Decoder::new(&buf, 0);
+        for _ in 0..super::MAXIMUM_DATA_STRUCTURE_DEPTH {
+            decoder.enter_nested().unwrap();
+        }
+
+        let error = <&str>::deserialize(&mut decoder).unwrap_err();
+        assert!(matches!(
+            *error,
+            MaxMindDbError::InvalidDatabase {
+                offset: Some(4),
+                ..
+            }
+        ));
+        assert!(error
+            .to_string()
+            .contains("exceeded maximum data structure depth"));
+        assert_eq!(decoder.offset(), 2);
+        assert_eq!(
+            decoder.state & super::DEPTH_MASK,
+            u32::from(super::MAXIMUM_DATA_STRUCTURE_DEPTH)
+        );
+        assert_eq!(u16::deserialize(&mut decoder).unwrap(), 42);
     }
 
     #[cfg(not(feature = "unsafe-str-decode"))]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -326,25 +326,25 @@ impl<'de> Decoder<'de> {
 
     /// Create an InvalidDatabase error with current offset context.
     #[inline]
-    fn invalid_db_error(&self, msg: &str) -> MaxMindDbError {
-        MaxMindDbError::invalid_database_at(msg, self.current_ptr)
+    fn invalid_db_error(&self, msg: &str) -> DecoderError {
+        MaxMindDbError::invalid_database_at(msg, self.current_ptr).into()
     }
 
     /// Create a Decoding error with current offset context.
     #[inline]
-    fn decode_error(&self, msg: &str) -> MaxMindDbError {
-        MaxMindDbError::decoding_at(msg, self.current_ptr)
+    fn decode_error(&self, msg: &str) -> DecoderError {
+        MaxMindDbError::decoding_at(msg, self.current_ptr).into()
     }
 
     /// Create a ResourceLimit error with current offset context.
     #[cold]
     #[inline(never)]
-    fn resource_limit_error(&self, msg: &str) -> MaxMindDbError {
-        MaxMindDbError::resource_limit_at(msg, self.current_ptr)
+    fn resource_limit_error(&self, msg: &str) -> DecoderError {
+        MaxMindDbError::resource_limit_at(msg, self.current_ptr).into()
     }
 
     #[inline(always)]
-    fn type_mismatch(&self, label: &str, type_num: usize) -> MaxMindDbError {
+    fn type_mismatch(&self, label: &str, type_num: usize) -> DecoderError {
         if type_num > usize::from(u8::MAX) {
             self.invalid_db_error(&format!("unknown data type: {type_num}"))
         } else {
@@ -459,7 +459,7 @@ impl<'de> Decoder<'de> {
             Value::Bytes(x) => visitor.visit_borrowed_bytes(x),
             Value::String(x) => visitor.visit_borrowed_str(x),
             Value::RawString(x) => {
-                visitor.visit_newtype_struct(BorrowedBytesDeserializer::<MaxMindDbError>::new(x))
+                visitor.visit_newtype_struct(BorrowedBytesDeserializer::<DecoderError>::new(x))
             }
             Value::I32(x) => visitor.visit_i32(x),
             Value::U16(x) => visitor.visit_u16(x),
@@ -1134,7 +1134,11 @@ impl<'de> Decoder<'de> {
     }
 }
 
-pub type DecodeResult<T> = Result<T, MaxMindDbError>;
+// Keep successful scalar and visitor results small by boxing the error.
+// Public reader methods return the original error after decoding finishes.
+pub(crate) type DecoderError = Box<MaxMindDbError>;
+
+pub type DecodeResult<T> = Result<T, DecoderError>;
 
 /// Deserializes any MaxMind DB value while exposing strings as raw bytes.
 ///
@@ -1175,7 +1179,7 @@ where
 }
 
 impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Decoder<'de> {
-    type Error = MaxMindDbError;
+    type Error = DecoderError;
 
     fn deserialize_any<V>(self, visitor: V) -> DecodeResult<V::Value>
     where
@@ -1404,7 +1408,7 @@ struct ArrayAccess<'a, 'de: 'a> {
 // `SeqAccess` is provided to the `Visitor` to give it the ability to iterate
 // through elements of the sequence.
 impl<'de> SeqAccess<'de> for ArrayAccess<'_, 'de> {
-    type Error = MaxMindDbError;
+    type Error = DecoderError;
 
     #[inline(always)]
     fn size_hint(&self) -> Option<usize> {
@@ -1443,7 +1447,7 @@ struct MapAccessor<'a, 'de: 'a, const BUDGETED: bool = false> {
 // `MapAccess` is provided to the `Visitor` to give it the ability to iterate
 // through entries of the map.
 impl<'de, const BUDGETED: bool> MapAccess<'de> for MapAccessor<'_, 'de, BUDGETED> {
-    type Error = MaxMindDbError;
+    type Error = DecoderError;
 
     #[inline(always)]
     fn size_hint(&self) -> Option<usize> {
@@ -1509,7 +1513,7 @@ struct EnumAccessor<'a, 'de: 'a> {
 }
 
 impl<'de> de::EnumAccess<'de> for EnumAccessor<'_, 'de> {
-    type Error = MaxMindDbError;
+    type Error = DecoderError;
     type Variant = Self;
 
     fn variant_seed<V>(self, seed: V) -> DecodeResult<(V::Value, Self::Variant)>
@@ -1523,7 +1527,7 @@ impl<'de> de::EnumAccess<'de> for EnumAccessor<'_, 'de> {
 }
 
 impl<'de> de::VariantAccess<'de> for EnumAccessor<'_, 'de> {
-    type Error = MaxMindDbError;
+    type Error = DecoderError;
 
     fn unit_variant(self) -> DecodeResult<()> {
         Ok(())
@@ -1958,7 +1962,7 @@ mod tests {
             let mut decoder = Decoder::new(&encoded, 0);
             let error = RawValueSeed.deserialize(&mut decoder).unwrap_err();
 
-            assert!(matches!(error, MaxMindDbError::InvalidDatabase { .. }));
+            assert!(matches!(*error, MaxMindDbError::InvalidDatabase { .. }));
             assert!(error.to_string().contains(&format!(
                 "unknown data type: {}",
                 u16::from(extended_type) + 7
@@ -1968,7 +1972,7 @@ mod tests {
             let typed_error =
                 <u32 as serde::Deserialize>::deserialize(&mut typed_decoder).unwrap_err();
             assert!(matches!(
-                typed_error,
+                *typed_error,
                 MaxMindDbError::InvalidDatabase { .. }
             ));
         }
@@ -2175,7 +2179,7 @@ mod tests {
             .skip_value_for_verification(&mut VerificationState::new(decoder.limit))
             .unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
     }
 
     #[cfg(not(feature = "unsafe-str-decode"))]
@@ -2219,7 +2223,7 @@ mod tests {
             let err = decoder
                 .skip_value_for_verification(&mut VerificationState::new(decoder.limit))
                 .unwrap_err();
-            assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+            assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
 
             // Every truncated payload must fail without advancing beyond the
             // header, even when bytes exist outside the decoder's limit.
@@ -2228,7 +2232,7 @@ mod tests {
                     let mut decoder = Decoder::new_with_limit(buf, 0, limit);
                     let err = serde::de::IgnoredAny::deserialize(&mut decoder).unwrap_err();
                     assert!(matches!(
-                        err,
+                        *err,
                         MaxMindDbError::InvalidDatabase { message, offset: Some(1) }
                             if message == format!("pointer of size {pointer_size}")
                     ));
@@ -2244,7 +2248,7 @@ mod tests {
         let mut decoder = Decoder::new(&[0x1d, 0x04, 0xff], 0);
         let err = Vec::<serde::de::IgnoredAny>::deserialize(&mut decoder).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
         assert!(err.to_string().contains("unexpected end of buffer"));
     }
 
@@ -2268,7 +2272,7 @@ mod tests {
         let mut decoder = Decoder::new(&[0xfe, 0x7e, 0xe3], 0);
         let err = serde::de::IgnoredAny::deserialize(&mut decoder).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum number of data structure values"));
@@ -2326,7 +2330,10 @@ mod tests {
                 } else {
                     decoder.deserialize_seq(visitor)
                 };
-                assert!(matches!(result, Err(MaxMindDbError::ResourceLimit { .. })));
+                assert!(matches!(
+                    result.map_err(|error| *error),
+                    Err(MaxMindDbError::ResourceLimit { .. })
+                ));
                 assert!(
                     !entered.get(),
                     "visitor entered: map={is_map}, dynamic={dynamic}"
@@ -2344,7 +2351,7 @@ mod tests {
         let err =
             Vec::<crate::geoip2::city::Subdivision<'_>>::deserialize(&mut decoder).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum number of data structure values"));
@@ -2361,7 +2368,7 @@ mod tests {
             std::collections::HashMap::<String, serde::de::IgnoredAny>::deserialize(&mut decoder)
                 .unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum number of data structure values"));
@@ -2390,7 +2397,7 @@ mod tests {
         let mut decoder = Decoder::new(&buf, array_offset);
         let err = Vec::<EmptyRecord>::deserialize(&mut decoder).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum number of data structure values"));
@@ -2406,7 +2413,7 @@ mod tests {
         let mut decoder = Decoder::new(&buf, array_offset);
         let err = Vec::<&str>::deserialize(&mut decoder).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum size of data structure string and bytes"));
@@ -2418,7 +2425,7 @@ mod tests {
         let mut decoder = Decoder::new(&buf, array_offset);
         let err = Vec::<OwnedBytes>::deserialize(&mut decoder).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum size of data structure string and bytes"));
@@ -2430,7 +2437,7 @@ mod tests {
         let mut decoder = Decoder::new(&buf, array_offset);
         let err = RawValueSeed.deserialize(&mut decoder).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum size of data structure string and bytes"));
@@ -2486,15 +2493,15 @@ mod tests {
 
         let mut decoder = Decoder::new(&buf, 0);
         let err = serde_json::Value::deserialize(&mut decoder).unwrap_err();
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
 
         let mut decoder = Decoder::new(&buf, 0);
         let err = RawValueSeed.deserialize(&mut decoder).unwrap_err();
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
 
         let mut decoder = Decoder::new(&buf, 0);
         let err = StandaloneScalarEnum::deserialize(&mut decoder).unwrap_err();
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
 
         // A directly requested typed scalar intentionally retains its
         // unbudgeted fast path because one scalar cannot amplify through
@@ -2586,7 +2593,7 @@ mod tests {
         let (buf, map_offset) = pointer_key_map(513);
         let mut decoder = Decoder::new(&buf, map_offset);
         let err = RawValueSeed.deserialize(&mut decoder).unwrap_err();
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum size of data structure string and bytes"));
@@ -2608,7 +2615,7 @@ mod tests {
         let (buf, map_offset) = pointer_key_map(513);
         let mut decoder = Decoder::new(&buf, map_offset);
         let err = decoder.deserialize_any(AnyKeyMapVisitor).unwrap_err();
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum size of data structure string and bytes"));
@@ -2654,7 +2661,7 @@ mod tests {
         let mut decoder = Decoder::new(&buf, map_offset);
         let err = Flattened::deserialize(&mut decoder).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum size of data structure string and bytes"));
@@ -2680,7 +2687,7 @@ mod tests {
         let mut decoder = Decoder::new(&buf, array_offset);
         let err = Vec::<Flattened>::deserialize(&mut decoder).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert!(err
             .to_string()
             .contains("maximum size of data structure string and bytes"));
@@ -2747,7 +2754,7 @@ mod tests {
         let mut decoder = Decoder::new(&buf, 8 * 4);
         let err = decoder.skip_value_for_verification(&mut state).unwrap_err();
         assert!(matches!(
-            err,
+            *err,
             MaxMindDbError::ResourceLimit {
                 offset: Some(36),
                 ..
@@ -2773,7 +2780,7 @@ mod tests {
                 Decoder::new(&buf, index * 2).skip_value_for_verification(&mut state)
             })
             .unwrap_err();
-        assert!(matches!(err, MaxMindDbError::ResourceLimit { .. }));
+        assert!(matches!(*err, MaxMindDbError::ResourceLimit { .. }));
         assert_eq!(state.work_remaining, 0);
         assert!(state.active.is_empty());
     }
@@ -2796,7 +2803,7 @@ mod tests {
         assert_eq!(state.work_remaining, usize::MAX);
         state.charge(usize::MAX, 0).unwrap();
         assert!(matches!(
-            state.charge(1, 0),
+            state.charge(1, 0).map_err(|error| *error),
             Err(MaxMindDbError::ResourceLimit { .. })
         ));
         assert_eq!(state.work_remaining, 0);
@@ -2810,7 +2817,7 @@ mod tests {
             .skip_value_for_verification(&mut VerificationState::new(decoder.limit))
             .unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
     }
 
     #[test]
@@ -2822,7 +2829,7 @@ mod tests {
             let mut decoder = Decoder::new(&buf, 0);
             let err = decoder.skip_value_for_verification(&mut state).unwrap_err();
 
-            assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+            assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
             assert!(err.to_string().contains("invalid UTF-8"));
             assert!(state.validated.is_empty());
             assert!(state.active.is_empty());
@@ -2880,7 +2887,7 @@ mod tests {
             .skip_value_for_verification(&mut VerificationState::new(decoder.limit))
             .unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
         assert!(err.to_string().contains("cyclic data pointer"));
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -142,6 +142,7 @@ macro_rules! deserialize_direct_scalar {
 
 macro_rules! deserialize_direct_payload {
     ($name:ident, $expected_type:expr, $label:literal, $visit:ident, $decode:ident) => {
+        #[cfg_attr(feature = "unsafe-str-decode", inline(always))]
         fn $name<V>(self, visitor: V) -> DecodeResult<V::Value>
         where
             V: Visitor<'de>,
@@ -776,29 +777,41 @@ impl<'de> Decoder<'de> {
     where
         F: FnOnce(&mut Self, usize) -> DecodeResult<T>,
     {
-        match type_num {
+        let (size, continuation) = match type_num {
             TYPE_POINTER => {
                 let new_ptr = self.decode_pointer(size);
                 let saved_ptr = self.current_ptr;
                 self.current_ptr = new_ptr;
                 self.enter_nested()?;
-                let result = (|| {
-                    let (size, type_num) = self.size_and_type()?;
+                let header = self.size_and_type().and_then(|(size, type_num)| {
                     if type_num == TYPE_POINTER {
-                        return Err(self.invalid_db_error("pointer points to another pointer"));
+                        Err(self.invalid_db_error("pointer points to another pointer"))
+                    } else if type_num != expected_type {
+                        Err(self.type_mismatch(label, type_num))
+                    } else {
+                        Ok(size)
                     }
-                    if type_num != expected_type {
-                        return Err(self.type_mismatch(label, type_num));
+                });
+                match header {
+                    Ok(size) => (size, Some(saved_ptr)),
+                    Err(error) => {
+                        self.exit_nested();
+                        self.current_ptr = saved_ptr;
+                        return Err(error);
                     }
-                    decode(self, size)
-                })();
-                self.exit_nested();
-                self.current_ptr = saved_ptr;
-                result
+                }
             }
-            t if t == expected_type => decode(self, size),
-            _ => Err(self.type_mismatch(label, type_num)),
+            t if t == expected_type => (size, None),
+            _ => return Err(self.type_mismatch(label, type_num)),
+        };
+        // One payload call lets visitor code inline without duplicating it
+        // for pointers and inline values.
+        let result = decode(self, size);
+        if let Some(saved_ptr) = continuation {
+            self.exit_nested();
+            self.current_ptr = saved_ptr;
         }
+        result
     }
 
     #[inline(always)]
@@ -2180,6 +2193,32 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
+    }
+
+    #[test]
+    fn typed_pointer_errors_restore_continuation_and_depth() {
+        let targets: &[&[u8]] = &[
+            &[],           // Missing target header.
+            &[0x5d],       // Truncated extended string length.
+            &[0xc0],       // Wrong type: uint32 instead of string.
+            &[0x20, 0],    // Pointer to another pointer.
+            &[0x41],       // Truncated string payload.
+            &[0x41, b'x'], // Valid string.
+        ];
+        for &target in targets {
+            let mut buf = vec![0x20, 4, 0xa1, 42];
+            buf.extend_from_slice(target);
+            let mut decoder = Decoder::new(&buf, 0);
+            let result = <&str>::deserialize(&mut decoder);
+            if target == [0x41, b'x'] {
+                assert_eq!(result.unwrap(), "x");
+            } else {
+                assert!(result.is_err());
+            }
+            assert_eq!(decoder.offset(), 2);
+            assert_eq!(decoder.state & super::DEPTH_MASK, 0);
+            assert_eq!(u16::deserialize(&mut decoder).unwrap(), 42);
+        }
     }
 
     #[cfg(not(feature = "unsafe-str-decode"))]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -75,13 +75,6 @@ const BUDGET_ACTIVE_MASK: u32 = 1 << 27;
 /// not explicitly request, so keep the limit below small default thread stacks.
 const MAXIMUM_SKIPPED_DATA_STRUCTURE_DEPTH: u16 = 128;
 
-#[inline(always)]
-fn to_usize(base: u8, bytes: &[u8]) -> usize {
-    bytes
-        .iter()
-        .fold(base as usize, |acc, &b| (acc << 8) | b as usize)
-}
-
 #[cfg(not(feature = "unsafe-str-decode"))]
 #[inline]
 fn is_ascii(bytes: &[u8]) -> bool {
@@ -665,7 +658,6 @@ impl<'de> Decoder<'de> {
 
     #[inline(always)]
     fn decode_pointer(&mut self, size: usize) -> usize {
-        let pointer_value_offset = [0, 0, 2048, 526_336, 0];
         let pointer_size = ((size >> 3) & 0x3) + 1;
         let p = self.current_ptr;
         let limit = self.limit;
@@ -681,14 +673,28 @@ impl<'de> Decoder<'de> {
         let pointer_bytes = self.slice(p, new_offset);
         self.current_ptr = new_offset;
 
-        let base = if pointer_size == 4 {
-            0
-        } else {
-            (size & 0x7) as u8
-        };
-        let unpacked = to_usize(base, pointer_bytes);
-
-        unpacked + pointer_value_offset[pointer_size]
+        match pointer_size {
+            1 => ((size & 0x7) << 8) | usize::from(pointer_bytes[0]),
+            2 => {
+                (((size & 0x7) << 16)
+                    | (usize::from(pointer_bytes[0]) << 8)
+                    | usize::from(pointer_bytes[1]))
+                    + 2048
+            }
+            3 => {
+                (((size & 0x7) << 24)
+                    | (usize::from(pointer_bytes[0]) << 16)
+                    | (usize::from(pointer_bytes[1]) << 8)
+                    | usize::from(pointer_bytes[2]))
+                    + 526_336
+            }
+            _ => {
+                (usize::from(pointer_bytes[0]) << 24)
+                    | (usize::from(pointer_bytes[1]) << 16)
+                    | (usize::from(pointer_bytes[2]) << 8)
+                    | usize::from(pointer_bytes[3])
+            }
+        }
     }
 
     #[cfg(feature = "unsafe-str-decode")]
@@ -2193,6 +2199,38 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
+    }
+
+    #[test]
+    fn pointer_widths_preserve_offsets_and_decoder_limits() {
+        let cases: &[(usize, &[u8], usize)] = &[
+            (0x00, &[0x00], 0),
+            (0x07, &[0xff], 2_047),
+            (0x08, &[0x00, 0x00], 2_048),
+            (0x0f, &[0xff, 0xff], 526_335),
+            (0x10, &[0x00, 0x00, 0x00], 526_336),
+            (0x10, &[0x01, 0x02, 0x03], 592_387),
+            (0x17, &[0xff, 0xff, 0xff], 134_744_063),
+            (0x18, &[0x00, 0x00, 0x00, 0x00], 0),
+            (0x1f, &[0xff, 0xff, 0xff, 0xff], 4_294_967_295),
+        ];
+        for &(size, payload, target) in cases {
+            let mut buf = vec![0];
+            buf.extend_from_slice(payload);
+            let continuation = buf.len();
+            buf.extend([0xa1, 42]);
+            let mut decoder = Decoder::new(&buf, 1);
+            assert_eq!(decoder.decode_pointer(size), target);
+            assert_eq!(decoder.offset(), continuation);
+            assert_eq!(u16::deserialize(&mut decoder).unwrap(), 42);
+
+            for limit in 1..continuation {
+                let mut decoder = Decoder::new_with_limit(&buf, 1, limit);
+                assert_eq!(decoder.decode_pointer(size), limit);
+                assert_eq!(decoder.offset(), limit);
+                assert!(u16::deserialize(&mut decoder).is_err());
+            }
+        }
     }
 
     #[test]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -710,9 +710,6 @@ impl<'de> Decoder<'de> {
     #[cfg(not(feature = "unsafe-str-decode"))]
     #[inline(always)]
     fn decode_string(&mut self, size: usize) -> DecodeResult<&'de str> {
-        #[cfg(feature = "simdutf8")]
-        use simdutf8::basic::from_utf8;
-        #[cfg(not(feature = "simdutf8"))]
         use std::str::from_utf8;
         use std::str::from_utf8_unchecked;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -195,6 +195,18 @@ impl de::Error for MaxMindDbError {
     }
 }
 
+impl From<Box<MaxMindDbError>> for MaxMindDbError {
+    fn from(error: Box<MaxMindDbError>) -> Self {
+        *error
+    }
+}
+
+impl de::Error for Box<MaxMindDbError> {
+    fn custom<T: Display>(msg: T) -> Self {
+        Box::new(MaxMindDbError::decoding(msg.to_string()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/geoip2.rs
+++ b/src/geoip2.rs
@@ -854,7 +854,7 @@ mod tests {
         let encoded = record_with_subdivisions(MAX_SUBDIVISIONS + 1);
         let err = City::deserialize(&mut Decoder::new(&encoded, 0)).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::Decoding { .. }));
+        assert!(matches!(*err, MaxMindDbError::Decoding { .. }));
         assert!(err
             .to_string()
             .contains("subdivisions exceeds maximum length of 32"));
@@ -865,7 +865,7 @@ mod tests {
         let encoded = record_with_subdivisions(MAX_SUBDIVISIONS + 1);
         let err = Enterprise::deserialize(&mut Decoder::new(&encoded, 0)).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::Decoding { .. }));
+        assert!(matches!(*err, MaxMindDbError::Decoding { .. }));
         assert!(err
             .to_string()
             .contains("subdivisions exceeds maximum length of 32"));
@@ -904,7 +904,7 @@ mod tests {
         let encoded = record_with_declared_subdivisions(MAX_SUBDIVISIONS + 1, 1);
         let err = City::deserialize(&mut Decoder::new(&encoded, 0)).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
         assert!(err.to_string().contains("unexpected end of buffer"));
     }
 
@@ -913,7 +913,7 @@ mod tests {
         let encoded = record_with_declared_subdivisions(MAX_SUBDIVISIONS + 1, 1);
         let err = Enterprise::deserialize(&mut Decoder::new(&encoded, 0)).unwrap_err();
 
-        assert!(matches!(err, MaxMindDbError::InvalidDatabase { .. }));
+        assert!(matches!(*err, MaxMindDbError::InvalidDatabase { .. }));
         assert!(err.to_string().contains("unexpected end of buffer"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,11 @@
 //!
 //! - **`mmap`** (default: disabled): Enable memory-mapped file access for
 //!   better performance in long-running applications
-//! - **`simdutf8`** (default: disabled): Use SIMD instructions for faster
-//!   UTF-8 validation during string decoding
 //! - **`unsafe-str-decode`** (default: disabled): Skip UTF-8 validation
 //!   when deserializing trusted database strings into Rust `str` or `String`
 //!   values. Cross-runtime format adapters should prefer
 //!   [`deserialize_any_with_raw_strings()`] and validate while constructing
 //!   the target runtime's string type.
-//!
-//! **Note**: `simdutf8` and `unsafe-str-decode` are mutually exclusive.
 //!
 //! ## Database Compatibility
 //!
@@ -73,9 +69,6 @@
 //!
 //! println!("Country: {:?}", country_code);
 //! ```
-
-#[cfg(all(feature = "simdutf8", feature = "unsafe-str-decode"))]
-compile_error!("features `simdutf8` and `unsafe-str-decode` are mutually exclusive");
 
 mod decoder;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,12 +103,14 @@ pub mod fuzzing {
     where
         T: Deserialize<'de>,
     {
-        T::deserialize(&mut Decoder::new(data, 0))
+        T::deserialize(&mut Decoder::new(data, 0)).map_err(Into::into)
     }
 
     /// Validate one data-section value through the verification decoder.
     pub fn verify(data: &[u8]) -> Result<(), MaxMindDbError> {
-        Decoder::new(data, 0).skip_value_for_verification(&mut VerificationState::new(data.len()))
+        Decoder::new(data, 0)
+            .skip_value_for_verification(&mut VerificationState::new(data.len()))
+            .map_err(Into::into)
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -34,8 +34,6 @@ const METADATA_START_MARKER: &[u8] = b"\xab\xcd\xefMaxMind.com";
 /// # Features
 ///
 /// - **`mmap`**: Enable memory-mapped file access for better performance
-/// - **`simdutf8`**: Use SIMD-accelerated UTF-8 validation (faster string
-///   decoding)
 /// - **`unsafe-str-decode`**: Skip UTF-8 validation when deserializing trusted
 ///   database strings into Rust `str` or `String` values. Cross-runtime format
 ///   adapters should prefer [`crate::deserialize_any_with_raw_strings()`].

--- a/src/result.rs
+++ b/src/result.rs
@@ -301,7 +301,8 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
         for (i, element) in path.iter().enumerate() {
             // Closure to add path context to errors during navigation.
             // Shows path up to and including the current element where the error occurred.
-            let with_path = |e| add_path_context(e, &path[..=i]);
+            let with_path =
+                |e: crate::decoder::DecoderError| add_path_context(e.into(), &path[..=i]);
 
             match *element {
                 PathElement::Key(key) => {
@@ -371,7 +372,7 @@ impl<'a, S: AsRef<[u8]>> LookupResult<'a, S> {
         // Decode the value at the current position
         T::deserialize(&mut decoder)
             .map(Some)
-            .map_err(|error| add_path_context(error, path))
+            .map_err(|error| add_path_context(error.into(), path))
     }
 }
 


### PR DESCRIPTION
Record decoding carries a large error value through successful scalar and Serde visitor calls. Box internal decoder errors, share the payload call between inline values and pointer targets, and decode pointer widths explicitly. Payload entry points also inline when UTF-8 validation is disabled. On the measured x86_64 build, a borrowed string result shrinks from 72 to 16 bytes. Public error types, context, and validation limits are preserved; constructing a decoder error adds one heap allocation.

Remove the `simdutf8` feature and optional dependency, along with its documentation and CI configuration. Production City and Country lookups showed no meaningful benefit from the option. This is a breaking feature removal: users must remove `simdutf8` from dependency feature lists when upgrading. The changelog records both the removal and the decoding improvements.

Local benchmarks against 0.31.0 used production GeoIP2 City and Country databases, including repeated IPv4, varied IPv4, and successful IPv6 lookups. Timings include full record decoding, allocations, and destruction.

| Configuration | Reduction in full lookup time |
|---|---:|
| Default features | 1.3–7.5% |
| UTF-8 validation disabled | 7.2–15.2% |

Partial-record and single-field decoding checks also improved by about 6–10%. Measurements used Rust 1.98.1 and Criterion 0.8.2 on an Intel Core Ultra 7 265K pinned to one performance core, with 40 samples, a 0.5-second warm-up, and 2-second measurement requests. Two runs reversed executable, feature, and library order. A default City run had timing outliers; its mean remains included above, and a separate focused repeat confirmed a 4.2% improvement.

The follow-up fix restores the pointer continuation when the nesting limit rejects a typed pointer, preserving the error offset and depth. Against the preceding PR head, production lookup timings ranged from -1.5% to +1.4%; a longer repeat of the largest apparent slowdown measured 523.4 ns before and 522.6 ns after. No consistent material performance regression was observed.

Validation:

- Every commit independently passed tests with default and all remaining features.
- Final state: 139 unit tests in each configuration, plus 22 default and 23 all-feature doctests.
- Added regression coverage for all pointer widths, truncated payloads and decoder limits, and restoring cursor/depth after typed pointer errors, including rejection at the nesting limit.
- Clippy with `mmap` and all features, rustfmt, documentation with warnings denied, and release-helper tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Removed the optional `simdutf8` feature and dependency. Use `mmap` or `unsafe-str-decode` where applicable.

- **Performance**
  - Improved record decoding efficiency and reduced internal processing overhead.

- **Bug Fixes**
  - Improved decoder error handling and path context reporting.
  - Added safeguards for pointer handling, decoder limits, and nested decoding.

- **Documentation**
  - Updated the README and changelog to reflect available features and decoding changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->