### PR TITLE
Speed up tree lookup and path-key decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   limit.
 - Improved search-tree lookup performance for 24-bit and 28-bit databases
   by reading each child pointer from a single word within the node.
+- Improved `decode_path()` performance by specializing map-key header
+  decoding for inline strings and all pointer widths, including long keys.
 
 ## 0.31.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   validation limits are unchanged.
 - Fixed decoder cursor restoration when a typed pointer exceeds the nesting
   limit.
+- Improved search-tree lookup performance for 24-bit and 28-bit databases
+  by reading each child pointer from a single word within the node.
 
 ## 0.31.0 - 2026-09-07
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -839,7 +839,44 @@ impl<'de> Decoder<'de> {
 
     /// Reads a string's bytes directly, following pointers if needed.
     /// Does NOT validate UTF-8.
+    #[inline]
     pub(crate) fn read_str_as_bytes(&mut self) -> DecodeResult<&'de [u8]> {
+        // Keys are strings, optionally behind one pointer. Handle those
+        // headers directly, including extended lengths, without retrying a
+        // general decode for valid inline strings or wider pointers.
+        let offset = self.current_ptr;
+        let ctrl = self.eat_byte()?;
+        match usize::from(ctrl >> 5) {
+            TYPE_STRING => {
+                let size = self.size_from_ctrl_byte(ctrl, TYPE_STRING)?;
+                self.count_payload(size)?;
+                return self.read_string_bytes(size);
+            }
+            TYPE_POINTER => {
+                let size = self.size_from_ctrl_byte(ctrl, TYPE_POINTER)?;
+                let target = self.decode_pointer(size);
+                let continuation = self.current_ptr;
+                self.current_ptr = target;
+                let ctrl = self.eat_byte()?;
+                if usize::from(ctrl >> 5) == TYPE_STRING {
+                    let size = self.size_from_ctrl_byte(ctrl, TYPE_STRING)?;
+                    let result = self
+                        .count_payload(size)
+                        .and_then(|()| self.read_string_bytes(size));
+                    self.current_ptr = continuation;
+                    return result;
+                }
+            }
+            _ => {}
+        }
+        self.current_ptr = offset;
+        self.read_str_as_bytes_slow()
+    }
+
+    // Preserve the general parser's error details and cursor behavior for
+    // unexpected types. Tests also use this as a reference for valid keys.
+    #[cold]
+    fn read_str_as_bytes_slow(&mut self) -> DecodeResult<&'de [u8]> {
         let (size, type_num) = self.size_and_type()?;
         match type_num {
             TYPE_POINTER => {
@@ -2232,6 +2269,97 @@ mod tests {
                 assert_eq!(decoder.decode_pointer(size), limit);
                 assert_eq!(decoder.offset(), limit);
                 assert!(u16::deserialize(&mut decoder).is_err());
+            }
+        }
+    }
+
+    fn compare_key_decoders(buf: &[u8], start: usize, limit: usize, remaining: u32) {
+        for budgeted in [false, true] {
+            let mut fast = Decoder::new_with_limit(buf, start, limit);
+            let mut general = Decoder::new_with_limit(buf, start, limit);
+            if budgeted {
+                fast.activate_budget();
+                general.activate_budget();
+            }
+            fast.payload_remaining = remaining;
+            general.payload_remaining = remaining;
+            let actual = fast.read_str_as_bytes().map_err(|e| format!("{e:?}"));
+            let expected = general
+                .read_str_as_bytes_slow()
+                .map_err(|e| format!("{e:?}"));
+            assert_eq!(
+                actual, expected,
+                "start={start}, limit={limit}, remaining={remaining}, budgeted={budgeted}"
+            );
+            assert_eq!(fast.current_ptr, general.current_ptr);
+            assert_eq!(fast.state, general.state);
+            assert_eq!(fast.payload_remaining, general.payload_remaining);
+        }
+    }
+
+    #[test]
+    fn key_decoding_preserves_values_errors_cursors_and_budgets() {
+        let mut buf = [0x61; 80];
+        buf[..2].copy_from_slice(&[0x20, 10]);
+        for control in 0..=255 {
+            buf[10] = control;
+            for limit in 0..=buf.len() {
+                for remaining in [0, 1, 2, 28, 29, 4096] {
+                    compare_key_decoders(&buf, 0, limit, remaining);
+                    compare_key_decoders(&buf, 10, limit, remaining);
+                }
+            }
+        }
+
+        let mut state = 0x4D59_5DF4_D0F3_3173_u64;
+        for _ in 0..8192 {
+            for byte in &mut buf {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                *byte = (state >> 32) as u8;
+            }
+            for start in [0, 1, 10, 79, 80, usize::MAX] {
+                compare_key_decoders(&buf, start, buf.len(), 0);
+                compare_key_decoders(&buf, start, buf.len(), 4096);
+            }
+        }
+
+        for pointer in 0..2048 {
+            let mut buf = [0x61; 2112];
+            buf[2080..2082].copy_from_slice(&[0x20 | ((pointer >> 8) as u8), pointer as u8]);
+            // Raw keys need not be valid UTF-8. Keep the pointer token after
+            // every possible target so it cannot overlap the string payload.
+            buf[pointer..pointer + 3].copy_from_slice(&[0x42, 0xFF, 0xFE]);
+            compare_key_decoders(&buf, 2080, buf.len(), 1);
+            compare_key_decoders(&buf, 2080, buf.len(), 2);
+        }
+    }
+
+    #[test]
+    fn key_decoders_agree_on_pointer_widths_and_extended_strings() {
+        let pointers: &[(&[u8], usize)] = &[
+            (&[0x20, 8], 8),
+            (&[0x28, 0, 0], 2048),
+            (&[0x30, 0, 0, 0], 526_336),
+            (&[0x38, 0, 0, 0, 8], 8),
+        ];
+        for &(pointer, target) in pointers {
+            for size in [0, 1, 28, 29, 285] {
+                let mut buf = pointer.to_vec();
+                buf.resize(target, 0);
+                match size {
+                    0..=28 => buf.push(0x40 | size as u8),
+                    29 => buf.extend_from_slice(&[0x5D, 0]),
+                    285 => buf.extend_from_slice(&[0x5E, 0, 0]),
+                    _ => unreachable!(),
+                }
+                buf.resize(buf.len() + size, b'k');
+                for limit in [pointer.len() - 1, target, buf.len() - 1, buf.len()] {
+                    for remaining in [0, 28, 4096] {
+                        compare_key_decoders(&buf, 0, limit, remaining);
+                    }
+                }
             }
         }
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -833,6 +833,8 @@ impl SearchTreeRecord for RecordSize28 {
         let bytes: [u8; 4] = buf[offset..offset + 4].try_into().unwrap();
         let word = u32::from_be_bytes(bytes);
         if index == 0 {
+            // The first three bytes hold bits 23..0, and the shared byte's
+            // high nibble holds bits 27..24. Move that nibble above the bytes.
             ((word >> 8) | ((word << 20) & 0x0F00_0000)) as usize
         } else {
             (word & 0x0FFF_FFFF) as usize
@@ -926,6 +928,16 @@ fn metadata_marker_start(metadata_start: usize) -> Result<usize, MaxMindDbError>
 #[cfg(test)]
 mod tests {
     use super::{RecordSize24, RecordSize28, RecordSize32, SearchTreeRecord};
+
+    #[test]
+    fn packed_28_bit_node_matches_spec_layout() {
+        // The MMDB specification places each child's most-significant nibble
+        // in the shared byte: [left low 24][left high 4 | right high 4][right low 24].
+        // https://maxmind.github.io/MaxMind-DB/#28-bits-medium-database-one-node-is-7-bytes
+        let node = [0x23, 0x45, 0x67, 0x18, 0x9A, 0xBC, 0xDE];
+        assert_eq!(RecordSize28::read_node(&node, 0, 0), 0x0123_4567);
+        assert_eq!(RecordSize28::read_node(&node, 0, 1), 0x089A_BCDE);
+    }
 
     #[test]
     fn packed_nodes_round_trip_both_children() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -229,6 +229,7 @@ impl<'de, S: AsRef<[u8]>> Reader<S> {
     /// # Ok(())
     /// # }
     /// ```
+    #[inline]
     pub fn lookup(&'de self, address: IpAddr) -> Result<LookupResult<'de, S>, MaxMindDbError> {
         match address {
             IpAddr::V4(v4) => {
@@ -812,8 +813,12 @@ struct RecordSize24;
 impl SearchTreeRecord for RecordSize24 {
     #[inline(always)]
     fn read_node(buf: &[u8], node_number: usize, index: usize) -> usize {
-        let offset = node_number * 6 + index * 3;
-        (buf[offset] as usize) << 16 | (buf[offset + 1] as usize) << 8 | buf[offset + 2] as usize
+        // Both four-byte windows stay inside the six-byte node. The left
+        // child occupies the high three bytes; the right occupies the low three.
+        let offset = node_number * 6 + index * 2;
+        let bytes: [u8; 4] = buf[offset..offset + 4].try_into().unwrap();
+        let word = u32::from_be_bytes(bytes);
+        ((word >> ((1 - index) * 8)) & 0x00FF_FFFF) as usize
     }
 }
 
@@ -822,17 +827,16 @@ struct RecordSize28;
 impl SearchTreeRecord for RecordSize28 {
     #[inline(always)]
     fn read_node(buf: &[u8], node_number: usize, index: usize) -> usize {
-        let base_offset = node_number * 7;
-        let middle = if index == 0 {
-            (buf[base_offset + 3] & 0xF0) >> 4
+        // The left window ends at the shared nibble byte; the right starts
+        // there. Each child and its shared nibble fit in a single word.
+        let offset = node_number * 7 + index * 3;
+        let bytes: [u8; 4] = buf[offset..offset + 4].try_into().unwrap();
+        let word = u32::from_be_bytes(bytes);
+        if index == 0 {
+            ((word >> 8) | ((word << 20) & 0x0F00_0000)) as usize
         } else {
-            buf[base_offset + 3] & 0x0F
-        };
-        let offset = base_offset + index * 4;
-        (middle as usize) << 24
-            | (buf[offset] as usize) << 16
-            | (buf[offset + 1] as usize) << 8
-            | buf[offset + 2] as usize
+            (word & 0x0FFF_FFFF) as usize
+        }
     }
 }
 
@@ -917,4 +921,68 @@ fn metadata_marker_start(metadata_start: usize) -> Result<usize, MaxMindDbError>
     metadata_start
         .checked_sub(METADATA_START_MARKER.len())
         .ok_or_else(|| MaxMindDbError::invalid_database("invalid metadata marker location"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RecordSize24, RecordSize28, RecordSize32, SearchTreeRecord};
+
+    #[test]
+    fn packed_nodes_round_trip_both_children() {
+        type ReadNode = fn(&[u8], usize, usize) -> usize;
+        let readers: [(usize, ReadNode); 3] = [
+            (24, RecordSize24::read_node),
+            (28, RecordSize28::read_node),
+            (32, RecordSize32::read_node),
+        ];
+        for (bits, read_node) in readers {
+            let node_size = bits / 4;
+            let mask = u32::MAX >> (32 - bits);
+            let mut state = 0x4D59_5DF4_D0F3_3173_u64;
+            let mut buf = [0u8; 24];
+            for sample in 0..65_536 {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                let (left, right) = match sample {
+                    0 => (0, mask),
+                    1 => (mask, 0),
+                    _ => (state as u32 & mask, (state >> 32) as u32 & mask),
+                };
+                // Exercise every shared-nibble combination for 28-bit records.
+                let (left, right) = if bits == 28 && sample >= 2 {
+                    (
+                        (left & 0x00FF_FFFF) | ((sample as u32 & 15) << 24),
+                        (right & 0x00FF_FFFF) | (((sample as u32 >> 4) & 15) << 24),
+                    )
+                } else {
+                    (left, right)
+                };
+                let node = sample % 3;
+                let start = node * node_size;
+                let end = start + node_size;
+                let encoded = &mut buf[start..end];
+                match bits {
+                    24 => {
+                        encoded[..3].copy_from_slice(&left.to_be_bytes()[1..]);
+                        encoded[3..].copy_from_slice(&right.to_be_bytes()[1..]);
+                    }
+                    28 => {
+                        encoded[..3].copy_from_slice(&left.to_be_bytes()[1..]);
+                        encoded[3] = ((left >> 20) as u8 & 0xF0) | (right >> 24) as u8;
+                        encoded[4..].copy_from_slice(&right.to_be_bytes()[1..]);
+                    }
+                    32 => {
+                        encoded[..4].copy_from_slice(&left.to_be_bytes());
+                        encoded[4..].copy_from_slice(&right.to_be_bytes());
+                    }
+                    _ => unreachable!(),
+                }
+                // Include unaligned nodes and end the buffer at this node:
+                // neither child may require a byte from the following node.
+                assert_eq!(read_node(&buf[..end], node, 0), left as usize);
+                assert_eq!(read_node(&buf[..end], node, 1), right as usize);
+            }
+        }
+    }
 }


### PR DESCRIPTION
IP lookup assembles 24-bit and 28-bit tree children from separate bytes, and path navigation uses general header decoding for map keys. This change reduces both costs while preserving the public API, bounds checks, borrowed values, UTF-8 validation, resource limits, and error/cursor behavior.

- Read 24-bit and 28-bit children using one checked four-byte window entirely inside the node. Use constant shifts for the 28-bit halves. The 32-bit reader already performs a single word load.
- Add `#[inline]` to `Reader::lookup`. In the measured nightly executable, this removes an `IpAddr` stack temporary and avoids the code placement responsible for a lookup benchmark regression.
- Specialize string and pointer key headers, including all pointer widths and extended string lengths. Valid keys do not retry through the general parser; unexpected types retain its error handling.
- Add independent node-encoding tests and differential key-decoder tests covering malformed/truncated input, offsets, cursor state, and budgets. The tree and key-decoder changes remain separate commits with changelog entries.

All 13 repository Criterion benchmarks were run with default features and with `mmap`, comparing the branch before and after the inline hint. Targeted repetitions also compared against main. Selected repeated results follow; times are **microseconds per whole Criterion iteration**, with 100 deterministic IPv4 addresses for lookup and the subset with records for cached decoding.

| Workload | Compiler | Main | Before inline hint | Final |
| --- | --- | ---: | ---: | ---: |
| Default: lookup + full City decode | Nightly | 45.779 | 47.844 | 44.355 |
| mmap: cached City decode | Nightly | 42.719 | 42.540 | 41.125 |
| Default: lookup + full City decode | Stable | 46.651 | 44.536 | 44.713 |

The final nightly default lookup is 7.3% faster than the unfixed branch and 3.1% faster than main. Stable retains the improvement over main; the difference from the unfixed branch is about +0.4%.

The unfixed tree change caused a repeatable roughly 5% slowdown in the nightly default-feature lookup benchmark. Profiling and disassembly showed faster tree traversal and unchanged decoder instruction sequences. A controlled post-link experiment that moved only the unchanged standard-library UTF-8 validator, retaining the existing call path and other function addresses, removed the slowdown. This establishes a code-placement cause; the exact CPU cache or predictor mechanism was not identified. The plain inline hint eliminates the observed regression without forcing inlining.

Small differences were rechecked. Across seven paired mmap city-name-path comparisons, medians were 6.788 → 6.783 µs, effectively unchanged; individual differences ranged from -1.54% to +1.48%. No new slowdown comparable to the original regression was reproduced in the full benchmark suite and targeted repetitions. Placement effects depend on the consuming executable, compiler, and CPU.

Measurements used Linux x86_64 on an Intel Core Ultra 7 265K, normal bench optimization, UTF-8 validation enabled, no custom Rust flags, separate target directories, and the same lockfile and immutable GeoLite2 City database. Serial runs were pinned to core 0; the parallel benchmark used cores 0–7 and eight Rayon workers. Builds, profiling, and timing ran separately. The full-suite comparison used 20 samples, a 1-second warmup, and 3-second measurement; the repeated nightly lookup and cached-City rows used a 3-second warmup and 5-second measurement. These are small, warm repository workloads.

- Nightly: `rustc 1.98.0-nightly (1f087276b 2026-06-13)`; stable: `rustc 1.96.0 (ac68faa20 2026-05-25)`.
- Baseline: main at `fe128ab9`, whose source matches `f16b1edf`. Before the hint: `21f75c3d`. Final: `fdb9f499`.
- GeoLite2 City SHA-256: `892f711a139a5c76dd2b7908f087148c729df287a504336daa2ccc7e2292ebbd`.

Validation passed on the final source:

- Stable tests and doctests with default, mmap, unsafe-str-decode, and combined features; mmap runs 143 unit tests and 23 doctests.
- Nightly release-mode mmap tests: 143 unit tests and 23 doctests.
- Formatting, Clippy over all targets with mmap and warnings denied, rustdoc with warnings denied, release-helper tests, and whitespace checks.
- All 13 Criterion cases with default features and mmap, plus targeted stable and repeat comparisons.

The rebased commit has exactly the same source tree as the tested and benchmarked working tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved search-tree lookup speed for 24-bit and 28-bit databases.
  - Improved path decoding performance for inline strings, varying pointer widths, and long keys.
  - Optimized string and pointer header processing while preserving parsing behavior and error handling.
- **Reliability**
  - Added comprehensive coverage for decoding across supported record sizes, boundaries, limits, pointer widths, and buffer conditions.
  - Verified consistent lookup results for unaligned data and records near buffer boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
