### PR TITLE
Speed up dynamic map-key decoding and expand dependency coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,20 @@
 version: 2
 updates:
   - package-ecosystem: cargo
-    directory: "/"
+    directories:
+      - "/"
+      - "/fuzz"
     schedule:
       interval: daily
       time: "13:00"
     open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "all"
   - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Reused precharged map-key bytes for raw identifier decoding, avoiding a
+  second header parse while preserving payload limits and other Serde entry
+  points. Added raw-string adapter and generic JSON decoding benchmarks.
 - Breaking: Removed the `simdutf8` feature and its optional dependency. It did
   not improve lookup performance in benchmarks using production GeoIP2 City
   and Country databases. Remove `simdutf8` from dependency feature lists when

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ cargo bench --bench lookup
 cargo bench --bench serde_usage
 ```
 
+The `serde_usage` suite covers typed records, ignored fields, generic JSON
+values, raw-string adapters, and selective paths. The `decode_raw_strings`
+case walks every record using borrowed identifier bytes and
+`deserialize_any_with_raw_strings`, as language bindings do, without adding
+another runtime's allocation costs. It detects decoder overhead that typed
+record benchmarks can miss.
+
 Criterion.rs generates an HTML report at `target/criterion/report/index.html`.
 It uses gnuplot when available and the bundled Plotters backend otherwise.
 

--- a/benches/raw_strings.rs
+++ b/benches/raw_strings.rs
@@ -1,0 +1,87 @@
+use maxminddb::deserialize_any_with_raw_strings;
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use std::fmt;
+use std::hint::black_box;
+
+/// Walk every value like a language binding, borrowing map keys and raw string
+/// bytes. Keep each decoded payload observable before counting it.
+pub struct RawStrings(pub usize);
+
+impl<'de> Deserialize<'de> for RawStrings {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserialize_any_with_raw_strings(deserializer, RawVisitor)
+    }
+}
+
+struct RawKey(usize);
+
+impl<'de> Deserialize<'de> for RawKey {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer
+            .deserialize_identifier(RawVisitor)
+            .map(|value| Self(value.0))
+    }
+}
+
+struct RawVisitor;
+
+impl<'de> Visitor<'de> for RawVisitor {
+    type Value = RawStrings;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an MMDB value")
+    }
+
+    fn visit_bool<E: de::Error>(self, value: bool) -> Result<Self::Value, E> {
+        black_box(value);
+        Ok(RawStrings(1))
+    }
+
+    fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+        black_box(value);
+        Ok(RawStrings(1))
+    }
+
+    fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+        black_box(value);
+        Ok(RawStrings(1))
+    }
+
+    fn visit_u128<E: de::Error>(self, value: u128) -> Result<Self::Value, E> {
+        black_box(value);
+        Ok(RawStrings(1))
+    }
+
+    fn visit_f64<E: de::Error>(self, value: f64) -> Result<Self::Value, E> {
+        black_box(value);
+        Ok(RawStrings(1))
+    }
+
+    fn visit_borrowed_bytes<E: de::Error>(self, bytes: &'de [u8]) -> Result<Self::Value, E> {
+        black_box(bytes);
+        Ok(RawStrings(bytes.len()))
+    }
+
+    fn visit_newtype_struct<D: Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_bytes(self)
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        let mut size = 0;
+        while let Some(value) = seq.next_element::<RawStrings>()? {
+            size += value.0;
+        }
+        Ok(RawStrings(size))
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut size = 0;
+        while let Some(key) = map.next_key::<RawKey>()? {
+            size += key.0 + map.next_value::<RawStrings>()?.0;
+        }
+        Ok(RawStrings(size))
+    }
+}

--- a/benches/serde_usage.rs
+++ b/benches/serde_usage.rs
@@ -6,6 +6,7 @@ use std::hint::black_box;
 use std::net::IpAddr;
 
 mod common;
+mod raw_strings;
 use common::{generate_ipv4, open_reader};
 
 const DB_FILE: &str = "GeoLite2-City.mmdb";
@@ -106,6 +107,20 @@ pub fn serde_usage_benchmark(c: &mut Criterion) {
     });
     c.bench_function("serde_usage/decode_empty_record", |b| {
         b.iter(|| bench_decode_empty_record(&cached_results))
+    });
+    c.bench_function("serde_usage/decode_json_value", |b| {
+        b.iter(|| {
+            for result in &cached_results {
+                black_box(result.decode::<serde_json::Value>().unwrap());
+            }
+        })
+    });
+    c.bench_function("serde_usage/decode_raw_strings", |b| {
+        b.iter(|| {
+            for result in &cached_results {
+                black_box(result.decode::<raw_strings::RawStrings>().unwrap());
+            }
+        })
     });
     c.bench_function("serde_usage/decode_path_country_iso", |b| {
         b.iter(|| bench_decode_path_country_iso(&cached_results))

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -15,7 +15,9 @@ use serde::forward_to_deserialize_any;
 
 use crate::error::MaxMindDbError;
 
+mod key;
 mod verification;
+use key::{CachedKey, KeyDeserializer};
 pub(crate) use verification::VerificationState;
 
 // MaxMind DB type constants
@@ -296,25 +298,50 @@ impl<'de> Decoder<'de> {
     /// Charges a string or bytes value at the current position without
     /// consuming it. Dynamically shaped maps use this for keys because a raw
     /// identifier visitor may copy them without requesting a string decode.
-    fn count_payload_at_current(&mut self) -> DecodeResult<bool> {
+    /// Retains complete string bytes for identifier visitors to reuse.
+    #[inline]
+    fn count_payload_at_current(&mut self) -> DecodeResult<(bool, Option<CachedKey<'de>>)> {
         let saved_ptr = self.current_ptr;
-        let result = (|| {
-            let (mut size, mut type_num) = self.size_and_type()?;
-            if type_num == TYPE_POINTER {
-                self.current_ptr = self.decode_pointer(size);
-                (size, type_num) = self.size_and_type()?;
-                if type_num == TYPE_POINTER {
-                    return Err(self.invalid_db_error("pointer points to another pointer"));
-                }
-            }
-            if type_num == TYPE_STRING || type_num == TYPE_BYTES {
-                self.count_payload(size)?;
-                return Ok(true);
-            }
-            Ok(false)
-        })();
+        let result = self.count_payload_at_current_inner();
         self.current_ptr = saved_ptr;
         result
+    }
+
+    // Inline the parsing body so callers that do not use raw identifiers can
+    // eliminate the cached bytes and continuation. Keep cursor restoration in
+    // the outer method so it also runs when parsing fails.
+    #[inline(always)]
+    fn count_payload_at_current_inner(&mut self) -> DecodeResult<(bool, Option<CachedKey<'de>>)> {
+        let (mut size, mut type_num) = self.size_and_type()?;
+        let mut continuation = None;
+        if type_num == TYPE_POINTER {
+            let target = self.decode_pointer(size);
+            continuation = Some(self.current_ptr);
+            self.current_ptr = target;
+            (size, type_num) = self.size_and_type()?;
+            if type_num == TYPE_POINTER {
+                return Err(self.invalid_db_error("pointer points to another pointer"));
+            }
+        }
+        if type_num == TYPE_STRING || type_num == TYPE_BYTES {
+            self.count_payload(size)?;
+            // Cache only complete string payloads. Leave malformed lengths
+            // to the requested Serde entry point so its errors and cursor
+            // restoration remain unchanged.
+            let cached = if type_num == TYPE_STRING {
+                self.current_ptr
+                    .checked_add(size)
+                    .filter(|&end| end <= self.limit)
+                    .map(|end| CachedKey {
+                        bytes: self.slice(self.current_ptr, end),
+                        continuation: continuation.unwrap_or(end),
+                    })
+            } else {
+                None
+            };
+            return Ok((true, cached));
+        }
+        Ok((false, None))
     }
 
     /// Create an InvalidDatabase error with current offset context.
@@ -1532,7 +1559,7 @@ impl<'de, const BUDGETED: bool> MapAccess<'de> for MapAccessor<'_, 'de, BUDGETED
 
         if BUDGETED {
             let payload_remaining_before = self.de.payload_remaining;
-            let payload_precharged = self.de.count_payload_at_current()?;
+            let (payload_precharged, cached) = self.de.count_payload_at_current()?;
             let payload_remaining_after = self.de.payload_remaining;
 
             // Let the seed perform its ordinary payload charge, while retaining
@@ -1540,7 +1567,12 @@ impl<'de, const BUDGETED: bool> MapAccess<'de> for MapAccessor<'_, 'de, BUDGETED
             // avoids disabling a budget that deserialize_any can reactivate and
             // keeps the ordinary payload counter free of a map-key-only branch.
             self.de.payload_remaining = payload_remaining_before;
-            let result = seed.deserialize(&mut *self.de).map(Some);
+            let result = seed
+                .deserialize(KeyDeserializer {
+                    decoder: self.de,
+                    cached,
+                })
+                .map(Some);
             if payload_precharged {
                 self.de.payload_remaining = self.de.payload_remaining.min(payload_remaining_after);
             }
@@ -1760,6 +1792,7 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy)]
     struct RawIdentifierSeed;
 
     impl<'de> DeserializeSeed<'de> for RawIdentifierSeed {
@@ -2831,6 +2864,128 @@ mod tests {
         assert!(err
             .to_string()
             .contains("maximum size of data structure string and bytes"));
+    }
+
+    fn compare_cached_key<'de, K>(
+        buf: &'de [u8],
+        start: usize,
+        limit: usize,
+        remaining: u32,
+        seed: K,
+    ) where
+        K: DeserializeSeed<'de> + Copy,
+        K::Value: fmt::Debug + PartialEq,
+    {
+        let mut cached = Decoder::new_with_limit(buf, start, limit);
+        let mut original = Decoder::new_with_limit(buf, start, limit);
+        for decoder in [&mut cached, &mut original] {
+            decoder.activate_budget();
+            decoder.payload_remaining = remaining;
+        }
+
+        let actual = super::MapAccessor::<true> {
+            de: &mut cached,
+            count: 2,
+        }
+        .next_key_seed(seed)
+        .map_err(|error| format!("{error:?}"));
+        // Reference the previous map-key algorithm: precharge, decode from the
+        // original cursor, then retain whichever payload charge is larger.
+        let expected = (|| {
+            let (charged, _) = original.count_payload_at_current()?;
+            let after = original.payload_remaining;
+            original.payload_remaining = remaining;
+            let result = seed.deserialize(&mut original).map(Some);
+            if charged {
+                original.payload_remaining = original.payload_remaining.min(after);
+            }
+            result
+        })()
+        .map_err(|error: super::DecoderError| format!("{error:?}"));
+
+        assert_eq!(
+            actual, expected,
+            "start={start}, limit={limit}, remaining={remaining}"
+        );
+        assert_eq!(cached.current_ptr, original.current_ptr);
+        assert_eq!(cached.state, original.state);
+        assert_eq!(cached.payload_remaining, original.payload_remaining);
+    }
+
+    #[test]
+    fn cached_map_keys_preserve_values_errors_cursors_and_budgets() {
+        let mut buf = [0x61; 80];
+        buf[..2].copy_from_slice(&[0x20, 10]);
+        for control in 0..=255 {
+            buf[10] = control;
+            for limit in 0..=buf.len() {
+                for remaining in [0, 1, 28, 32, 4096] {
+                    compare_cached_key(&buf, 0, limit, remaining, RawIdentifierSeed);
+                    compare_cached_key(&buf, 10, limit, remaining, RawIdentifierSeed);
+                }
+            }
+        }
+        for &(pointer, target) in &[
+            (&[0x20, 8][..], 8),
+            (&[0x28, 0, 0][..], 2048),
+            (&[0x30, 0, 0, 0][..], 526_336),
+            (&[0x38, 0, 0, 0, 8][..], 8),
+        ] {
+            let mut buf = pointer.to_vec();
+            buf.resize(target, 0);
+            buf.extend([0x5e, 0, 0]); // 285-byte string
+            buf.resize(buf.len() + 285, 0xff); // identifiers preserve raw UTF-8 bytes
+            for limit in [pointer.len() - 1, target, buf.len() - 1, buf.len()] {
+                for remaining in [0, 284, 285, 4096] {
+                    compare_cached_key(&buf, 0, limit, remaining, RawIdentifierSeed);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn cached_map_keys_preserve_other_serde_entry_points() {
+        use std::marker::PhantomData;
+
+        let cases: &[&[u8]] = &[
+            &[0x41, b'x'],
+            &[0x20, 4, 0xa1, 42, 0x41, b'x'],
+            &[0x20, 4, 0xa1, 42, 0x41],
+            &[0x81, 0xff], // bytes are not string identifiers
+            &[0xa1, 42],
+            &[0xe0],
+        ];
+        for &buf in cases {
+            for remaining in [0, 1, 4096] {
+                compare_cached_key(buf, 0, buf.len(), remaining, PhantomData::<String>);
+                compare_cached_key(
+                    buf,
+                    0,
+                    buf.len(),
+                    remaining,
+                    PhantomData::<serde_json::Value>,
+                );
+                compare_cached_key(
+                    buf,
+                    0,
+                    buf.len(),
+                    remaining,
+                    PhantomData::<serde::de::IgnoredAny>,
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(not(feature = "unsafe-str-decode"))]
+    fn cached_map_keys_do_not_bypass_utf8_validation_for_strings() {
+        use std::marker::PhantomData;
+
+        for buf in [&[0x41, 0xff][..], &[0x20, 2, 0x41, 0xff][..]] {
+            compare_cached_key(buf, 0, buf.len(), 4096, PhantomData::<String>);
+            compare_cached_key(buf, 0, buf.len(), 4096, PhantomData::<serde_json::Value>);
+            compare_cached_key(buf, 0, buf.len(), 4096, RawIdentifierSeed);
+        }
     }
 
     #[test]

--- a/src/decoder/key.rs
+++ b/src/decoder/key.rs
@@ -1,0 +1,80 @@
+//! Reuse the string header resolved while charging a dynamic map key.
+
+use super::{DecodeResult, Decoder, DecoderError};
+use serde::de::{Deserializer, Visitor};
+
+pub(super) struct CachedKey<'de> {
+    pub bytes: &'de [u8],
+    pub continuation: usize,
+}
+
+pub(super) struct KeyDeserializer<'a, 'de> {
+    pub decoder: &'a mut Decoder<'de>,
+    pub cached: Option<CachedKey<'de>>,
+}
+
+// Only identifier decoding uses the cached raw bytes. Other Serde entry points
+// retain the decoder's type checks, UTF-8 validation, and pointer-depth checks.
+macro_rules! delegate {
+    ($($method:ident $(($($arg:ident: $ty:ty),*))?;)*) => {
+        $(
+            #[inline]
+            fn $method<V: Visitor<'de>>(self, $($($arg: $ty,)*)? visitor: V) -> DecodeResult<V::Value> {
+                self.decoder.$method($($($arg,)*)? visitor)
+            }
+        )*
+    };
+}
+
+impl<'de> Deserializer<'de> for KeyDeserializer<'_, 'de> {
+    type Error = DecoderError;
+
+    #[inline]
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> DecodeResult<V::Value> {
+        if let Some(key) = self.cached {
+            // The map accessor has already checked and reserved the entire
+            // payload. It retains that charge after this visitor returns.
+            self.decoder.current_ptr = key.continuation;
+            visitor.visit_borrowed_bytes(key.bytes)
+        } else {
+            self.decoder.deserialize_identifier(visitor)
+        }
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.decoder.is_human_readable()
+    }
+
+    delegate! {
+        deserialize_any;
+        deserialize_bool;
+        deserialize_i8;
+        deserialize_i16;
+        deserialize_i32;
+        deserialize_i64;
+        deserialize_i128;
+        deserialize_u8;
+        deserialize_u16;
+        deserialize_u32;
+        deserialize_u64;
+        deserialize_u128;
+        deserialize_f32;
+        deserialize_f64;
+        deserialize_char;
+        deserialize_str;
+        deserialize_string;
+        deserialize_bytes;
+        deserialize_byte_buf;
+        deserialize_option;
+        deserialize_unit;
+        deserialize_unit_struct(name: &'static str);
+        deserialize_newtype_struct(name: &'static str);
+        deserialize_seq;
+        deserialize_tuple(len: usize);
+        deserialize_tuple_struct(name: &'static str, len: usize);
+        deserialize_map;
+        deserialize_struct(name: &'static str, fields: &'static [&'static str]);
+        deserialize_enum(name: &'static str, variants: &'static [&'static str]);
+        deserialize_ignored_any;
+    }
+}


### PR DESCRIPTION
Dynamic map decoding reads string-key headers during payload precharging and again when a raw identifier visitor requests them. Reuse complete, bounds-checked string bytes and the continuation cursor from precharging for `deserialize_identifier`, avoiding the second parse.

Keep parsing in an `#[inline(always)]` helper so non-identifier callers can eliminate unused cache construction. Preserve full payload charging, malformed-input errors, and cursor restoration. Raw identifiers continue to return unvalidated bytes; other Serde entry points retain their existing string-validation behavior.

Add `serde_usage/decode_raw_strings` for the decoder path used by language bindings and `decode_json_value` for generic owned decoding. Pass decoded scalars and borrowed slices through `black_box` in the raw visitors to keep payload decoding observable. Differential tests cover identifiers, all pointer widths, truncated inputs, payload boundaries, invalid UTF-8, and other Serde entry points.

A separate commit expands Dependabot to cover both Cargo projects (`/` and `/fuzz`), all Cargo dependency types, and weekly test-data submodule updates. Existing Cargo and GitHub Actions schedules are preserved.

### Performance

The latest native comparison uses main at `4e47001b` and the source tree now at `41c36976`, Rust 1.98.1, default features, an Intel Core Ultra 7 265K, Linux x86_64, and CPU 2 affinity. Both builds use identical dependency locks and corrected benchmark files. Timed runs did not overlap compilation or other benchmarks. The database is a historical full GeoLite2 City database (33,733,040 bytes, SHA-256 `d38c97fa421687f7c52fc2a04ddc5a9f89690e3cd702d30acaf999facb3d4474`).

Native results use independently rebuilt binaries and seven alternating-order rounds, with 30 Criterion samples per round, 0.2 s warmup, 0.5 s measurement, and 5,000 resamples. Values are medians of per-round mean estimates, per benchmark iteration over sampled records, not per record. Negative time changes are faster.

| Workload | Main | This branch | Time change |
| --- | ---: | ---: | ---: |
| Raw strings | 37.300 µs | 31.339 µs | -15.98% |
| Typed City | 37.624 µs | 37.728 µs | +0.28% |
| Typed Country | 28.779 µs | 28.714 µs | -0.22% |
| JSON value | 277.492 µs | 276.061 µs | -0.52% |
| Empty record | 4.509 µs | 4.467 µs | -0.92% |
| Country ISO path | 3.238 µs | 3.248 µs | +0.32% |
| City name path | 2.661 µs | 2.616 µs | -1.71% |
| Lookup only | 2.408 µs | 2.410 µs | +0.11% |

Raw decoding is 15.98% faster in this run. The other seven workloads range from 1.71% faster to 0.32% slower. Generated-code inspection confirms that JSON/String key decoding eliminates unused cache construction; the typed and selective-path decoding functions examined retain unchanged instructions after relocation normalization.

Separate Ruby 3.4.7 binding measurements show fixed-hit throughput increasing from 424,494 to 439,009/s (**+3.42%**; 11 rotating-order samples of 500,000 lookups after 100,000 warmups). Allocations are identical at 8,000,015 objects per sample. The Ruby extension uses LTO.

The separate Ruby lookup comparison uses nine alternating samples of 200,000 operations across eight cases. Full-record and batch throughput improve by 3.35% and 2.78%; selective-path throughput changes range from −1.16% to +0.10%. Iteration throughput improves by 0.96%. Shared-reader throughput across 1, 2, 4, and 8 threads improves by 2.12% to 3.35%. Allocation medians and cache-root retention are unchanged.

Small differences varied between runs. These results are specific to the tested environment and do not establish a portable zero-regression guarantee.

### Validation

- Default features: 146 unit tests and 22 doctests pass.
- All features: 145 unit tests and 23 doctests pass.
- Clippy with all targets under `mmap` and all features, `cargo fmt --check`, and diff checks pass.
- Separate rebuilt Ruby integration: 92 tests / 1,211 assertions and 5 official-gem parity tests / 23 assertions pass, including resource-limit and malformed-database coverage.
- Dependabot configuration passes JSON schema validation; changed Markdown/YAML passes Prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved decoding performance for raw map identifiers by reusing previously read key data.
  - Preserved payload limits, UTF-8 validation, cursor handling, and supported Serde decoding behavior.

- **Documentation**
  - Expanded benchmark documentation to cover typed records, ignored fields, generic JSON values, raw-string adapters, and selective paths.

- **Tests**
  - Added benchmarks for raw-string decoding and generic JSON value decoding to help track performance across common usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
